### PR TITLE
Fix the "floor_divide is deprecated" warning in torch 1.9.1

### DIFF
--- a/torchquad/integration/vegas_stratification.py
+++ b/torchquad/integration/vegas_stratification.py
@@ -110,7 +110,7 @@ class VEGASStratification:
         res = torch.zeros([len(idx), self.dim])
         tmp = idx
         for i in range(self.dim):
-            q = tmp // self.N_strat
+            q = torch.div(tmp, self.N_strat, rounding_mode="floor")
             r = tmp - q * self.N_strat
             res[:, i] = r
             tmp = q


### PR DESCRIPTION
The warning messages shown in the github actions run: https://github.com/esa/torchquad/runs/3522994424#step:6:69