### PR TITLE
Add a flake8 configuration file and use it for a code linting github action job

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,11 @@
+[flake8]
+extend-ignore =
+	# Allow whitespace before ':' because in some cases this whitespace
+	# avoids confusing the operator precedence,
+	# e.g. "arr[1 : k + p]" instead of "arr[1:k + p]"
+	E203,
+	# Allow module imports not at top of file so that numerical backends
+	# can be imported only if needed
+	E402,
+	# Allow very long lines
+	E501

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
   workflow_dispatch:
 jobs:
-  build:
+  lint_flake8:
 
     runs-on: ubuntu-latest
 
@@ -24,7 +24,22 @@ jobs:
     - name: Lint with flake8
       run: |
         pip install flake8
+        flake8 . --count --show-source --statistics
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Search for severe code errors with flake8
+      run: |
         # stop the build if there are Python syntax errors or undefined names
+        pip install flake8
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
     #     # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
     #     flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,7 +10,8 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import sys, os
+import sys
+import os
 
 sys.path.insert(0, os.path.abspath("../../"))
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ https://github.com/pypa/sampleproject
 """
 
 # Always prefer setuptools over distutils
-from setuptools import setup, find_packages
+from setuptools import setup
 
 setup(
     name="torchquad",

--- a/torchquad/integration/monte_carlo.py
+++ b/torchquad/integration/monte_carlo.py
@@ -1,7 +1,6 @@
 from autoray import numpy as anp
 from autoray import infer_backend
 from loguru import logger
-import warnings
 
 from .base_integrator import BaseIntegrator
 from .utils import _setup_integration_domain, _RNG

--- a/torchquad/plots/plot_convergence.py
+++ b/torchquad/plots/plot_convergence.py
@@ -12,8 +12,7 @@ def plot_convergence(evals, fvals, ground_truth, labels, dpi=150):
         labels (list): Method names.
         dpi (int, optional): Plot dpi. Defaults to 150.
     """
-    fig = plt.figure(dpi=dpi)
-    n = 0
+    plt.figure(dpi=dpi)
     for evals_item, f_item, label in zip(evals, fvals, labels):
         evals_item = np.array(evals_item)
         abs_err = np.abs(np.asarray(f_item) - np.asarray(ground_truth))

--- a/torchquad/plots/plot_runtime.py
+++ b/torchquad/plots/plot_runtime.py
@@ -11,7 +11,7 @@ def plot_runtime(evals, runtime, labels, dpi=150, y_axis_name="Runtime [s]"):
         dpi (int, optional): Plot dpi. Defaults to 150.
         y_axis_name (str, optional): Name for y axis. Deafults to "Runtime [s]".
     """
-    fig = plt.figure(dpi=dpi)
+    plt.figure(dpi=dpi)
     for evals_item, rt, label in zip(evals, runtime, labels):
         plt.semilogy(evals_item, rt, label=label)
     plt.legend(fontsize=6)

--- a/torchquad/tests/integration_test_functions.py
+++ b/torchquad/tests/integration_test_functions.py
@@ -28,7 +28,7 @@ class IntegrationTestFunction:
 
         self.is_complex = is_complex
         # Initialize domain to [-1,1]^dim if not passed
-        if domain == None:
+        if domain is None:
             self.domain = torch.tensor([[-1, 1]] * self.dim)
         else:
             self.domain = domain

--- a/torchquad/tests/monte_carlo_test.py
+++ b/torchquad/tests/monte_carlo_test.py
@@ -2,8 +2,6 @@ import sys
 
 sys.path.append("../")
 
-import torch
-
 from integration.monte_carlo import MonteCarlo
 from utils.enable_cuda import enable_cuda
 from utils.set_precision import set_precision

--- a/torchquad/tests/vegas_test.py
+++ b/torchquad/tests/vegas_test.py
@@ -3,8 +3,8 @@ import sys
 sys.path.append("../")
 
 import timeit
-
-import cProfile, pstats
+import cProfile
+import pstats
 
 from integration.vegas import VEGAS
 from utils.enable_cuda import enable_cuda


### PR DESCRIPTION
I think that identifying unused variables can sometimes help to find typing errors and unused imports can unnecessarily slow down the startup time in some situations, so I made the flake8 lint more strict.