### PR TITLE
Use the TORCHQUAD_LOG_LEVEL environment variable for the default log level if it exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ mc = MonteCarlo()
 # Compute the function integral by sampling 10000 points over domain 
 integral_value = mc.integrate(some_function,dim=2,N=10000,integration_domain = [[0,1],[-1,1]])
 ```
+To change the logger verbosity, set the `TORCHQUAD_LOG_LEVEL` environment
+variable; for example `export TORCHQUAD_LOG_LEVEL=WARNING`.
 
 You can find all available integrators [here](https://torchquad.readthedocs.io/en/main/integration_methods.html).
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -33,6 +33,9 @@ Minimal working example
     # Compute the function integral by sampling 10000 points over domain 
     integral_value = mc.integrate(some_function,dim=2,N=10000,integration_domain = [[0,1],[-1,1]])
 
+To set the default logger verbosity, change the ``TORCHQUAD_LOG_LEVEL``
+environment variable; for example ``export TORCHQUAD_LOG_LEVEL=WARNING``.
+
 Detailed Introduction
 ---------------------
 

--- a/torchquad/__init__.py
+++ b/torchquad/__init__.py
@@ -37,5 +37,5 @@ __all__ = [
     "_deployment_test",
 ]
 
-set_log_level("INFO")
+set_log_level(os.environ.get("TORCHQUAD_LOG_LEVEL", "INFO"))
 logger.info("Initializing torchquad.")

--- a/torchquad/utils/set_log_level.py
+++ b/torchquad/utils/set_log_level.py
@@ -3,7 +3,9 @@ import sys
 
 
 def set_log_level(log_level: str):
-    """Set the log level for the logger
+    """Set the log level for the logger.
+    The preset log level when initialising Torchquad is the value of the TORCHQUAD_LOG_LEVEL environment variable, or 'INFO' if the environment variable is unset.
+
     Args:
         log_level (str): The log level to set. Options are 'TRACE','DEBUG', 'INFO', 'SUCCESS', 'WARNING', 'ERROR', 'CRITICAL'
     """


### PR DESCRIPTION
A small one-line change so that the default log level can be changed with an environment variable