### PR TITLE
Extend the existing integration rule tests for other backends than torch

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -50,4 +50,4 @@ jobs:
       run: |
         cd torchquad/tests
         conda install pytest
-        $CONDA/bin/pytest
+        $CONDA/bin/pytest -ra

--- a/torchquad/tests/boole_test.py
+++ b/torchquad/tests/boole_test.py
@@ -8,6 +8,7 @@ from integration.boole import Boole
 from utils.enable_cuda import enable_cuda
 from utils.set_precision import set_precision
 from utils.set_log_level import set_log_level
+from integration_test_utils import compute_test_errors
 
 
 def test_integrate():
@@ -16,9 +17,6 @@ def test_integrate():
     set_log_level("INFO")
     enable_cuda()
     set_precision("double")
-
-    # Needs to happen after precision / device settings to avoid having some tensors intialized on cpu and some on GPU
-    from integration_test_utils import compute_test_errors
 
     bl = Boole()
     # 1D Tests

--- a/torchquad/tests/boole_test.py
+++ b/torchquad/tests/boole_test.py
@@ -8,35 +8,37 @@ from integration.boole import Boole
 from utils.enable_cuda import enable_cuda
 from utils.set_precision import set_precision
 from utils.set_log_level import set_log_level
-from integration_test_utils import compute_test_errors
+from integration_test_utils import run_example_functions
 
 
-def test_integrate():
-    """Tests the integrate function in integration.Boole.
+def _run_boole_tests(backend):
+    """Test the integrate function in integration.Boole for the given backend.
     Note: For now the 10-D test is diabled due to lack of GPU memory on some computers."""
-    set_log_level("INFO")
-    enable_cuda()
-    set_precision("double")
 
     bl = Boole()
     # 1D Tests
     N = 401
 
-    errors = compute_test_errors(bl.integrate, {"N": N, "dim": 1}, use_complex=True)
-    print("1D Boole Test: Passed N =", N, "\n", "Errors: ", errors)
+    errors, funcs = run_example_functions(
+        bl.integrate, {"N": N, "dim": 1}, dim=1, use_complex=True, backend=backend
+    )
+    print(f"1D Boole Test passed. N: {N}, backend: {backend}, Errors: {errors}")
+    # Polynomials up to degree 5 can be integrated almost exactly with Boole.
+    for err, test_function in zip(errors, funcs):
+        assert test_function.get_order() > 5 or err < 6.33e-11
     for error in errors:
-        assert error < 1e-11
+        assert error < 6.33e-11
 
     # 3D Tests
     N = 1076890  # N = 102.5 per dim (will change to 101 if all works)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        errors = compute_test_errors(
-            bl.integrate, {"N": N, "dim": 3}, dim=3, use_complex=True
+        errors, funcs = run_example_functions(
+            bl.integrate, {"N": N, "dim": 3}, dim=3, use_complex=True, backend=backend
         )
-    print("3D Boole Test: Passed N =", N, "\n", "Errors: ", errors)
-    for error in errors[:3]:
-        assert error < 2e-13
+    print(f"3D Boole Test passed. N: {N}, backend: {backend}, Errors: {errors}")
+    for err, test_function in zip(errors, funcs):
+        assert test_function.get_order() > 5 or err < 2e-13
     for error in errors:
         assert error < 5e-6
 
@@ -49,6 +51,32 @@ def test_integrate():
     # assert error < 5e-9
 
 
+def test_integrate_numpy():
+    """Test the integrate function in integration.Boole with Numpy"""
+    set_log_level("INFO")
+    _run_boole_tests("numpy")
+
+
+def test_integrate_torch():
+    """Test the integrate function in integration.Boole with Torch"""
+    set_log_level("INFO")
+    enable_cuda()
+    set_precision("double", backend="torch")
+    _run_boole_tests("torch")
+
+
+def test_integrate_jax():
+    """Test the integrate function in integration.Boole with Torch"""
+    set_log_level("INFO")
+    set_precision("double", backend="jax")
+    _run_boole_tests("jax")
+
+
+# Skip tensorflow since it does not yet support double as global precision
+
+
 if __name__ == "__main__":
     # used to run this test individually
-    test_integrate()
+    test_integrate_numpy()
+    test_integrate_torch()
+    test_integrate_jax()

--- a/torchquad/tests/boole_test.py
+++ b/torchquad/tests/boole_test.py
@@ -8,7 +8,7 @@ from integration.boole import Boole
 from utils.enable_cuda import enable_cuda
 from utils.set_precision import set_precision
 from utils.set_log_level import set_log_level
-from integration_test_utils import run_example_functions
+from integration_test_utils import compute_integration_test_errors
 
 
 def _run_boole_tests(backend):
@@ -19,7 +19,7 @@ def _run_boole_tests(backend):
     # 1D Tests
     N = 401
 
-    errors, funcs = run_example_functions(
+    errors, funcs = compute_integration_test_errors(
         bl.integrate, {"N": N, "dim": 1}, dim=1, use_complex=True, backend=backend
     )
     print(f"1D Boole Test passed. N: {N}, backend: {backend}, Errors: {errors}")
@@ -33,7 +33,7 @@ def _run_boole_tests(backend):
     N = 1076890  # N = 102.5 per dim (will change to 101 if all works)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        errors, funcs = run_example_functions(
+        errors, funcs = compute_integration_test_errors(
             bl.integrate, {"N": N, "dim": 3}, dim=3, use_complex=True, backend=backend
         )
     print(f"3D Boole Test passed. N: {N}, backend: {backend}, Errors: {errors}")

--- a/torchquad/tests/boole_test.py
+++ b/torchquad/tests/boole_test.py
@@ -2,17 +2,16 @@ import sys
 
 sys.path.append("../")
 
-import pytest
 import warnings
 
 from integration.boole import Boole
-from utils.enable_cuda import enable_cuda
-from utils.set_precision import set_precision
-from utils.set_log_level import set_log_level
-from integration_test_utils import compute_integration_test_errors
+from integration_test_utils import (
+    compute_integration_test_errors,
+    setup_test_for_backend,
+)
 
 
-def _run_boole_tests(backend):
+def _run_boole_tests(backend, _precision):
     """Test the integrate function in integration.Boole for the given backend.
     Note: For now the 10-D test is diabled due to lack of GPU memory on some computers."""
 
@@ -52,30 +51,9 @@ def _run_boole_tests(backend):
     # assert error < 5e-9
 
 
-def test_integrate_numpy():
-    """Test the integrate function in integration.Boole with Numpy"""
-    pytest.importorskip("numpy")
-    set_log_level("INFO")
-    _run_boole_tests("numpy")
-
-
-def test_integrate_torch():
-    """Test the integrate function in integration.Boole with Torch"""
-    pytest.importorskip("torch")
-    set_log_level("INFO")
-    enable_cuda()
-    set_precision("double", backend="torch")
-    _run_boole_tests("torch")
-
-
-def test_integrate_jax():
-    """Test the integrate function in integration.Boole with JAX"""
-    pytest.importorskip("jax")
-    set_log_level("INFO")
-    set_precision("double", backend="jax")
-    _run_boole_tests("jax")
-
-
+test_integrate_numpy = setup_test_for_backend(_run_boole_tests, "numpy", "double")
+test_integrate_torch = setup_test_for_backend(_run_boole_tests, "torch", "double")
+test_integrate_jax = setup_test_for_backend(_run_boole_tests, "jax", "double")
 # Skip tensorflow since it does not yet support double as global precision
 
 

--- a/torchquad/tests/boole_test.py
+++ b/torchquad/tests/boole_test.py
@@ -2,6 +2,7 @@ import sys
 
 sys.path.append("../")
 
+import pytest
 import warnings
 
 from integration.boole import Boole
@@ -53,12 +54,14 @@ def _run_boole_tests(backend):
 
 def test_integrate_numpy():
     """Test the integrate function in integration.Boole with Numpy"""
+    pytest.importorskip("numpy")
     set_log_level("INFO")
     _run_boole_tests("numpy")
 
 
 def test_integrate_torch():
     """Test the integrate function in integration.Boole with Torch"""
+    pytest.importorskip("torch")
     set_log_level("INFO")
     enable_cuda()
     set_precision("double", backend="torch")
@@ -66,7 +69,8 @@ def test_integrate_torch():
 
 
 def test_integrate_jax():
-    """Test the integrate function in integration.Boole with Torch"""
+    """Test the integrate function in integration.Boole with JAX"""
+    pytest.importorskip("jax")
     set_log_level("INFO")
     set_precision("double", backend="jax")
     _run_boole_tests("jax")

--- a/torchquad/tests/integration_test_functions.py
+++ b/torchquad/tests/integration_test_functions.py
@@ -1,5 +1,6 @@
-import torch
-
+from autoray import numpy as anp
+from autoray import infer_backend
+from numpy import inf
 from loguru import logger
 
 
@@ -14,7 +15,9 @@ class IntegrationTestFunction:
     f = None  # Function to evaluate
     is_complex = False  # If the test function contains complex numbers
 
-    def __init__(self, expected_result, dim=1, domain=None, is_complex=False):
+    def __init__(
+        self, expected_result, dim=1, domain=None, is_complex=False, backend="torch"
+    ):
         """Initializes domain and stores variables.
 
         Args:
@@ -22,6 +25,7 @@ class IntegrationTestFunction:
             dim (int, optional): Dimensionality of investigated function. Defaults to 1.
             domain (list, optional): Integration domain, e.g. [[0,1],[1,2]]. Defaults to None.
             is_complex (Boolean): If the test function contains complex numbers. Defaults to False.
+            backend (string, optional): Numerical backend. This argument is ignored if the backend can be inferred from domain. Defaults to "torch".
         """
         self.dim = dim
         self.expected_result = expected_result
@@ -29,7 +33,11 @@ class IntegrationTestFunction:
         self.is_complex = is_complex
         # Initialize domain to [-1,1]^dim if not passed
         if domain is None:
-            self.domain = torch.tensor([[-1, 1]] * self.dim)
+            self.domain = anp.array([[-1.0, 1.0]] * self.dim, like=backend)
+        elif infer_backend(domain) == "builtins":
+            # Ensure that integration domain numbers are always a python floats
+            domain = [list(map(float, dlist)) for dlist in domain]
+            self.domain = anp.array(domain, like=backend)
         else:
             self.domain = domain
         logger.debug("Initialized Test function with ")
@@ -52,73 +60,139 @@ class IntegrationTestFunction:
         Returns:
             float: Integration result
         """
-        return integrator(fn=self.f, integration_domain=self.domain, **integration_args)
+
+        def integrand(x):
+            assert infer_backend(self.domain) == infer_backend(x), (
+                "Integration domain and points have a different backend:"
+                f" {infer_backend(self.domain)} and {infer_backend(x)}"
+            )
+            assert self.domain.dtype == x.dtype, (
+                "Integration domain and points have a different dtype:"
+                f" {self.domain.dtype} and {x.dtype}"
+            )
+            return self.f(x)
+
+        return integrator(
+            fn=integrand, integration_domain=self.domain, **integration_args
+        )
+
+    def get_order(self):
+        """Get the order (polynomial degree) of the function
+
+        Returns:
+            float: Order of the function or infinity if it is not a finite polynomial
+        """
+        return inf if self.order is None else self.order
 
 
 class Polynomial(IntegrationTestFunction):
     def __init__(
-        self, expected_result=None, coeffs=[2], dim=1, domain=None, is_complex=False
+        self,
+        expected_result=None,
+        coeffs=[2],
+        dim=1,
+        domain=None,
+        is_complex=False,
+        backend="torch",
     ):
         """Creates an n-dimensional, degree-K poylnomial test function.
 
         Args:
-            expected_result (torch.tensor): Expected result. Required to compute errors.
+            expected_result (backend tensor): Expected result. Required to compute errors.
             coeffs (list, optional): Polynomial coefficients. Are the same for each dim. Defaults to [2].
             dim (int, optional): Polynomial dimensionality. Defaults to 1.
             domain (list, optional): Integration domain. Defaults to [-1.0, 1.0]^dim.
             is_complex (Boolean): If the test function contains complex numbers. Defaults to False.
+            backend (string, optional): Numerical backend. This argument is ignored if the backend can be inferred from domain. Defaults to "torch".
         """
-        super().__init__(expected_result, dim, domain, is_complex)
-        self.coeffs = torch.tensor(coeffs)
+        super().__init__(expected_result, dim, domain, is_complex, backend)
+        if backend == "tensorflow":
+            # Ensure than all coefficients are either Python3 float or Python3
+            # complex since tensorflow requires this.
+            if is_complex:
+                coeffs = list(map(complex, coeffs))
+            else:
+                coeffs = list(map(float, coeffs))
+        self.coeffs = anp.array(coeffs, like=self.domain)
         self.order = len(coeffs) - 1  # polynomial order is defined by the coeffs
         self.f = self._poly
 
     def _poly(self, x):
-        # compute x^k
-        exponentials = torch.zeros([x.shape[0], x.shape[1], self.order + 1])
-        for o in range(self.order + 1):
-            exponentials[:, :, o] = torch.pow(x, o)
+        # Compute all relevant x^k
+        # The shape of exponentials is (dim, N, order+1)
+        if infer_backend(x) != "tensorflow":
+            exponentials = x.reshape(x.shape + (1,)) ** anp.linspace(
+                0, self.order, self.order + 1, like=x
+            )
+            assert exponentials.dtype == x.dtype
+        else:
+            # Tensorflow's exponentiation gives float64 values if x are float32
+            # and the exponent are integer
+            ks = anp.array(range(self.order + 1), dtype=x.dtype, like=x)
+            exponentials = x.reshape(x.shape + (1,)) ** ks
+            assert exponentials.dtype == x.dtype
+            if exponentials.dtype != self.coeffs.dtype:
+                # Tensorflow does not automatically cast float32 to complex128,
+                # so we do it here explicitly.
+                assert self.is_complex
+                exponentials = anp.cast(exponentials, self.coeffs.dtype)
 
         # multiply by coefficients
-        exponentials = torch.multiply(exponentials, self.coeffs)
+        exponentials = anp.multiply(exponentials, self.coeffs)
 
         # Collapse dimensions
-        exponentials = torch.sum(exponentials, dim=2)
+        exponentials = anp.sum(exponentials, axis=2)
 
         # sum all values for each dim
-        return torch.sum(exponentials, dim=1)
+        return anp.sum(exponentials, axis=1)
 
 
 class Exponential(IntegrationTestFunction):
-    def __init__(self, expected_result=None, dim=1, domain=None, is_complex=False):
+    def __init__(
+        self,
+        expected_result=None,
+        dim=1,
+        domain=None,
+        is_complex=False,
+        backend="torch",
+    ):
         """Creates an n-dimensional exponential test function.
 
         Args:
-            expected_result (torch.tensor): Expected result. Required to compute errors.
+            expected_result (backend tensor): Expected result. Required to compute errors.
             dim (int, optional): Input dimension. Defaults to 1.
             domain (list, optional): Integration domain. Defaults to [-1.0, 1.0]^dim.
             is_complex (Boolean): If the test function contains complex numbers. Defaults to False.
+            backend (string, optional): Numerical backend. This argument is ignored if the backend can be inferred from domain. Defaults to "torch".
         """
-        super().__init__(expected_result, dim, domain, is_complex)
+        super().__init__(expected_result, dim, domain, is_complex, backend)
         self.f = self._exp
 
     def _exp(self, x):
         # compute e^x
-        return torch.sum(torch.exp(x), dim=1)
+        return anp.sum(anp.exp(x), axis=1)
 
 
 class Sinusoid(IntegrationTestFunction):
-    def __init__(self, expected_result=None, dim=1, domain=None, is_complex=False):
+    def __init__(
+        self,
+        expected_result=None,
+        dim=1,
+        domain=None,
+        is_complex=False,
+        backend="torch",
+    ):
         """Creates an n-dimensional sinusoidal test function.
 
         Args:
-            expected_result (torch.tensor): Expected result. Required to compute errors.
+            expected_result (backend tensor): Expected result. Required to compute errors.
             dim (int, optional): Input dimension. Defaults to 1.
             domain (list, optional): Integration domain. Defaults to [-1.0, 1.0]^dim.
             is_complex (Boolean): If the test function contains complex numbers. Defaults to False.
+            backend (string, optional): Numerical backend. This argument is ignored if the backend can be inferred from domain. Defaults to "torch".
         """
-        super().__init__(expected_result, dim, domain, is_complex)
+        super().__init__(expected_result, dim, domain, is_complex, backend)
         self.f = self._sinusoid
 
     def _sinusoid(self, x):
-        return torch.sum(torch.sin(x), dim=1)
+        return anp.sum(anp.sin(x), axis=1)

--- a/torchquad/tests/integration_test_utils.py
+++ b/torchquad/tests/integration_test_utils.py
@@ -141,7 +141,7 @@ def get_test_functions(dim, backend):
         raise ValueError("Not testing functions implemented for dim " + str(dim))
 
 
-def run_example_functions(
+def compute_integration_test_errors(
     integrator,
     integrator_args,
     dim,
@@ -189,29 +189,3 @@ def run_example_functions(
         chosen_functions.append(test_function)
 
     return errors, chosen_functions
-
-
-def compute_test_errors(
-    integrator,
-    integrator_args,
-    dim=1,
-    use_complex=False,
-    backend="torch",
-):
-    """Computes errors on all test functions for given dimension and integrator.
-
-    Args:
-        integrator (torchquad.base_integrator): Integrator to use.
-        integrator_args (dict): Arguments for the integrator.
-        dim (int, optional): Dimensionality of test functions to use. Defaults to 1.
-        use_complex (Boolean, optional): If complex test functions should be used. Defaults to False.
-        backend (string, optional): Numerical backend for the test functions. Defaults to "torch".
-
-    Returns:
-        list: Absolute errors on all test functions
-    """
-    errors, _ = run_example_functions(
-        integrator, integrator_args, dim, use_complex, backend
-    )
-
-    return errors

--- a/torchquad/tests/integration_test_utils.py
+++ b/torchquad/tests/integration_test_utils.py
@@ -3,63 +3,192 @@ import numpy as np
 from integration_test_functions import Polynomial, Exponential, Sinusoid
 
 
-# Here we define a bunch of functions that will be used for testing
-TEST_FUNCTIONS_1D = [
-    # Real numbers
-    Polynomial(4.0, [2.0], is_complex=False),  # y = 2
-    Polynomial(0, [0, 1], is_complex=False),  # y = x
-    Polynomial(2 / 3, [0, 0, 2], domain=[[0, 1]], is_complex=False),  # y = 2x^2
-    # y = -3x^3+2x^2-x+3
-    Polynomial(27.75, [3, -1, 2, -3], domain=[[-2, 1]], is_complex=False),
-    # y = 7x^4-3x^3+2x^2-x+3
-    Polynomial(44648.0 / 15.0, [3, -1, 2, -3, 7], domain=[[-4, 4]], is_complex=False),
-    # # y = -x^5+7x^4-3x^3+2x^2-x+3
-    Polynomial(8939.0 / 60.0, [3, -1, 2, -3, 7, -1], domain=[[2, 3]], is_complex=False),
-    Exponential(np.exp(1) - np.exp(-2), domain=[[-2, 1]], is_complex=False),
-    Exponential((np.exp(2) - 1.0) / np.exp(3), domain=[[-3, -1]], is_complex=False),
-    Sinusoid(2 * np.sin(1) * np.sin(1), domain=[[0, 2]], is_complex=False),
-    #
-    # Complex numbers
-    Polynomial(4.0j, [2.0j], is_complex=True),  # y = 2j
-    Polynomial(0, [0, 1j], is_complex=True),  # y = xj
-    # y=7x^4-3jx^3+2x^2-jx+3
-    Polynomial(44648.0 / 15.0, [3, -1j, 2, -3j, 7], domain=[[-4, 4]], is_complex=True),
-]
+def get_test_functions(dim, backend):
+    """Here we define a bunch of functions that will be used for testing.
 
-TEST_FUNCTIONS_3D = [
-    # Real numbers
-    Polynomial(48.0, [2.0], dim=3, is_complex=False),  # f(x,y,z) = 2
-    Polynomial(0, [0, 1], dim=3, is_complex=False),  # f(x,y,z) = x + y + z
-    # f(x,y,z) = x^2+y^2+z^2
-    Polynomial(8.0, coeffs=[0, 0, 1], dim=3, is_complex=False),
-    # e^x+e^y+e^z
-    Exponential(
-        27 * (np.exp(3) - 1) / np.exp(2),
-        domain=[[-2, 1], [-2, 1], [-2, 1]],
-        is_complex=False,
-    ),
-    Sinusoid(24 * np.sin(1) ** 2, domain=[[0, 2], [0, 2], [0, 2]], is_complex=False),
-    # e^x+e^y+e^z
-    Exponential(
-        1.756,
-        domain=[[-0.05, 0.1], [-0.25, 0.2], [-np.exp(1), np.exp(1)]],
-        is_complex=False,
-    ),
-    #
-    # Complex numbers
-    Polynomial(48.0j, [2.0j], dim=3, is_complex=True),  # f(x,y,z) = 2j
-    Polynomial(0, [0, 1.0j], dim=3, is_complex=True),  # f(x,y,z) = xj
-    Polynomial(8.0j, coeffs=[0, 0, 1.0j], dim=3, is_complex=True),  # j*x^2+j*y^2+j*z^2
-]
+    Args:
+        dim (int): Dimensionality of test functions to use.
+        backend (string): Numerical backend used for the integration
+    """
+    if dim == 1:
+        return [
+            # Real numbers
+            Polynomial(4.0, [2.0], is_complex=False, backend=backend),  # y = 2
+            Polynomial(0, [0, 1], is_complex=False, backend=backend),  # y = x
+            Polynomial(
+                2 / 3, [0, 0, 2], domain=[[0, 1]], is_complex=False, backend=backend
+            ),  # y = 2x^2
+            # y = -3x^3+2x^2-x+3
+            Polynomial(
+                27.75,
+                [3, -1, 2, -3],
+                domain=[[-2, 1]],
+                is_complex=False,
+                backend=backend,
+            ),
+            # y = 7x^4-3x^3+2x^2-x+3
+            Polynomial(
+                44648.0 / 15.0,
+                [3, -1, 2, -3, 7],
+                domain=[[-4, 4]],
+                is_complex=False,
+                backend=backend,
+            ),
+            # # y = -x^5+7x^4-3x^3+2x^2-x+3
+            Polynomial(
+                8939.0 / 60.0,
+                [3, -1, 2, -3, 7, -1],
+                domain=[[2, 3]],
+                is_complex=False,
+                backend=backend,
+            ),
+            Exponential(
+                np.exp(1) - np.exp(-2),
+                domain=[[-2, 1]],
+                is_complex=False,
+                backend=backend,
+            ),
+            Exponential(
+                (np.exp(2) - 1.0) / np.exp(3),
+                domain=[[-3, -1]],
+                is_complex=False,
+                backend=backend,
+            ),
+            Sinusoid(
+                2 * np.sin(1) * np.sin(1),
+                domain=[[0, 2]],
+                is_complex=False,
+                backend=backend,
+            ),
+            #
+            # Complex numbers
+            Polynomial(4.0j, [2.0j], is_complex=True, backend=backend),  # y = 2j
+            Polynomial(0, [0, 1j], is_complex=True, backend=backend),  # y = xj
+            # y=7x^4-3jx^3+2x^2-jx+3
+            Polynomial(
+                44648.0 / 15.0,
+                [3, -1j, 2, -3j, 7],
+                domain=[[-4, 4]],
+                is_complex=True,
+                backend=backend,
+            ),
+        ]
+    elif dim == 3:
+        return [
+            # Real numbers
+            Polynomial(
+                48.0, [2.0], dim=3, is_complex=False, backend=backend
+            ),  # f(x,y,z) = 2
+            Polynomial(
+                0, [0, 1], dim=3, is_complex=False, backend=backend
+            ),  # f(x,y,z) = x + y + z
+            # f(x,y,z) = x^2+y^2+z^2
+            Polynomial(8.0, coeffs=[0, 0, 1], dim=3, is_complex=False, backend=backend),
+            # e^x+e^y+e^z
+            Exponential(
+                27 * (np.exp(3) - 1) / np.exp(2),
+                domain=[[-2, 1], [-2, 1], [-2, 1]],
+                is_complex=False,
+                backend=backend,
+            ),
+            Sinusoid(
+                24 * np.sin(1) ** 2,
+                domain=[[0, 2], [0, 2], [0, 2]],
+                is_complex=False,
+                backend=backend,
+            ),
+            # e^x+e^y+e^z
+            Exponential(
+                1.756,
+                domain=[[-0.05, 0.1], [-0.25, 0.2], [-np.exp(1), np.exp(1)]],
+                is_complex=False,
+                backend=backend,
+            ),
+            #
+            # Complex numbers
+            Polynomial(
+                48.0j, [2.0j], dim=3, is_complex=True, backend=backend
+            ),  # f(x,y,z) = 2j
+            Polynomial(
+                0, [0, 1.0j], dim=3, is_complex=True, backend=backend
+            ),  # f(x,y,z) = xj
+            Polynomial(
+                8.0j, coeffs=[0, 0, 1.0j], dim=3, is_complex=True, backend=backend
+            ),  # j*x^2+j*y^2+j*z^2
+        ]
+    elif dim == 10:
+        return [
+            # Real numbers
+            # f(x_1, ..., x_10) = x_1^2+x_2^2+...
+            Polynomial(
+                3413.33333333,
+                coeffs=[0, 0, 1],
+                dim=10,
+                is_complex=False,
+                backend=backend,
+            ),
+            # Complex numbers
+            # f(x_1, ..., x_10) = j*x_1^2+j*x_2^2+...
+            Polynomial(
+                3413.33333333j,
+                coeffs=[0, 0, 1.0j],
+                dim=10,
+                is_complex=True,
+                backend=backend,
+            ),
+        ]
+    else:
+        raise ValueError("Not testing functions implemented for dim " + str(dim))
 
-TEST_FUNCTIONS_10D = [
-    # Real numbers
-    # f(x_1, ..., x_10) = x_1^2+x_2^2+...
-    Polynomial(3413.33333333, coeffs=[0, 0, 1], dim=10, is_complex=False),
-    # Complex numbers
-    # f(x_1, ..., x_10) = j*x_1^2+j*x_2^2+...
-    Polynomial(3413.33333333j, coeffs=[0, 0, 1.0j], dim=10, is_complex=True),
-]
+
+def run_example_functions(
+    integrator,
+    integrator_args,
+    dim,
+    use_complex,
+    backend,
+):
+    """Computes errors on all test functions for given dimension and integrator.
+
+    Args:
+        integrator (torchquad.base_integrator): Integrator to use.
+        integrator_args (dict): Arguments for the integrator.
+        dim (int): Dimensionality of the example functions to choose.
+        use_complex (Boolean): If True, skip complex example functions.
+        backend (string): Numerical backend for the example functions.
+
+    Returns:
+        (list, list): Absolute errors on all example functions and the chosen
+            example functions
+    """
+    errors = []
+    chosen_functions = []
+
+    # Compute integration errors on the chosen functions and remember those
+    # functions
+    for test_function in get_test_functions(dim, backend):
+        if not use_complex and test_function.is_complex:
+            continue
+        if backend == "torch":
+            errors.append(
+                np.abs(
+                    test_function.evaluate(integrator, integrator_args)
+                    .cpu()
+                    .detach()
+                    .numpy()
+                    - test_function.expected_result
+                )
+            )
+        else:
+            errors.append(
+                np.abs(
+                    test_function.evaluate(integrator, integrator_args)
+                    - test_function.expected_result
+                )
+            )
+        chosen_functions.append(test_function)
+
+    return errors, chosen_functions
 
 
 def compute_test_errors(
@@ -67,6 +196,7 @@ def compute_test_errors(
     integrator_args,
     dim=1,
     use_complex=False,
+    backend="torch",
 ):
     """Computes errors on all test functions for given dimension and integrator.
 
@@ -75,43 +205,13 @@ def compute_test_errors(
         integrator_args (dict): Arguments for the integrator.
         dim (int, optional): Dimensionality of test functions to use. Defaults to 1.
         use_complex (Boolean, optional): If complex test functions should be used. Defaults to False.
+        backend (string, optional): Numerical backend for the test functions. Defaults to "torch".
 
     Returns:
         list: Absolute errors on all test functions
     """
-    errors = []
-
-    # Get the test functions
-    if dim == 1:
-        test_functions = TEST_FUNCTIONS_1D
-    elif dim == 3:
-        test_functions = TEST_FUNCTIONS_3D
-    elif dim == 10:
-        test_functions = TEST_FUNCTIONS_10D
-    else:
-        raise ValueError("Not testing functions implemented for dim " + str(dim))
-
-    # Compute integration errors on all of them
-    for test_function in test_functions:
-        if not test_function.is_complex:
-            errors.append(
-                np.abs(
-                    test_function.evaluate(integrator, integrator_args)
-                    .cpu()
-                    .detach()
-                    .numpy()
-                    - test_function.expected_result
-                )
-            )
-        if test_function.is_complex and use_complex:
-            errors.append(
-                np.abs(
-                    test_function.evaluate(integrator, integrator_args)
-                    .cpu()
-                    .detach()
-                    .numpy()
-                    - test_function.expected_result
-                )
-            )
+    errors, _ = run_example_functions(
+        integrator, integrator_args, dim, use_complex, backend
+    )
 
     return errors

--- a/torchquad/tests/monte_carlo_test.py
+++ b/torchquad/tests/monte_carlo_test.py
@@ -6,7 +6,7 @@ from integration.monte_carlo import MonteCarlo
 from utils.enable_cuda import enable_cuda
 from utils.set_precision import set_precision
 from utils.set_log_level import set_log_level
-from integration_test_utils import run_example_functions
+from integration_test_utils import compute_integration_test_errors
 
 from tensorflow.python.ops.numpy_ops import np_config
 
@@ -21,7 +21,7 @@ def _run_monte_carlo_tests(backend):
     # 1D Tests
     N = 100000  # integration points to use
 
-    errors, funcs = run_example_functions(
+    errors, funcs = compute_integration_test_errors(
         mc.integrate,
         {"N": N, "dim": 1, "seed": 0},
         dim=1,
@@ -51,7 +51,7 @@ def _run_monte_carlo_tests(backend):
 
     # 3D Tests
     N = 1000000
-    errors, funcs = run_example_functions(
+    errors, funcs = compute_integration_test_errors(
         mc.integrate,
         {"N": N, "dim": 3, "seed": 0},
         dim=3,
@@ -68,7 +68,7 @@ def _run_monte_carlo_tests(backend):
 
     # 10D Tests
     N = 10000
-    errors, funcs = run_example_functions(
+    errors, funcs = compute_integration_test_errors(
         mc.integrate,
         {"N": N, "dim": 10, "seed": 0},
         dim=10,

--- a/torchquad/tests/monte_carlo_test.py
+++ b/torchquad/tests/monte_carlo_test.py
@@ -6,24 +6,36 @@ from integration.monte_carlo import MonteCarlo
 from utils.enable_cuda import enable_cuda
 from utils.set_precision import set_precision
 from utils.set_log_level import set_log_level
-from integration_test_utils import compute_test_errors
+from integration_test_utils import run_example_functions
+
+from tensorflow.python.ops.numpy_ops import np_config
+
+np_config.enable_numpy_behavior()
 
 
-def test_integrate():
-    """Tests the integrate function in integration.MonteCarlo."""
-    set_log_level("INFO")
-    enable_cuda()
-    set_precision("double")
+def _run_monte_carlo_tests(backend):
+    """Test the integrate function in integration.MonteCarlo for the given backend."""
 
     mc = MonteCarlo()
 
     # 1D Tests
     N = 100000  # integration points to use
 
-    errors = compute_test_errors(
-        mc.integrate, {"N": N, "dim": 1, "seed": 0}, use_complex=True
+    errors, funcs = run_example_functions(
+        mc.integrate,
+        {"N": N, "dim": 1, "seed": 0},
+        dim=1,
+        use_complex=True,
+        backend=backend,
     )
-    print("1D Monte Carlo Test: Passed N =", N, "\n", "Errors: ", errors)
+    print(
+        f"1D Monte Carlo Test passed. N: {N}, backend: {backend}, Errors: {str(errors)}"
+    )
+    # Constant functions can be integrated exactly with MonteCarlo.
+    # (at least our example functions)
+    for err, test_function in zip(errors, funcs):
+        assert test_function.get_order() > 0 or err == 0.0
+
     # If this breaks check if test functions in integration_test_utils changed.
     for error in errors[:3]:
         assert error < 7e-3
@@ -32,30 +44,78 @@ def test_integrate():
         assert error < 28.0
 
     for error in errors[6:10]:
-        assert error < 47e-4
+        assert error < 1e-2
 
     for error in errors[10:]:
-        assert error < 28.0
+        assert error < 28.03
 
     # 3D Tests
     N = 1000000
-    errors = compute_test_errors(
-        mc.integrate, {"N": N, "dim": 3, "seed": 0}, dim=3, use_complex=True
+    errors, funcs = run_example_functions(
+        mc.integrate,
+        {"N": N, "dim": 3, "seed": 0},
+        dim=3,
+        use_complex=True,
+        backend=backend,
     )
-    print("3D Monte Carlo Test: Passed N =", N, "\n", "Errors: ", errors)
+    print(
+        f"3D Monte Carlo Test passed. N: {N}, backend: {backend}, Errors: {str(errors)}"
+    )
+    for err, test_function in zip(errors, funcs):
+        assert test_function.get_order() > 0 or err == 0.0
     for error in errors:
         assert error < 1e-1
 
     # 10D Tests
     N = 10000
-    errors = compute_test_errors(
-        mc.integrate, {"N": N, "dim": 10, "seed": 0}, dim=10, use_complex=True
+    errors, funcs = run_example_functions(
+        mc.integrate,
+        {"N": N, "dim": 10, "seed": 0},
+        dim=10,
+        use_complex=True,
+        backend=backend,
     )
-    print("10D Monte Carlo Test: Passed N =", N, "\n", "Errors: ", errors)
+    print(
+        f"10D Monte Carlo Test passed. N: {N}, backend: {backend}, Errors:"
+        f" {str(errors)}"
+    )
+    for err, test_function in zip(errors, funcs):
+        assert test_function.get_order() > 0 or err == 0.0
     for error in errors:
-        assert error < 13
+        assert error < 26
+
+
+def test_integrate_numpy():
+    """Test the integrate function in integration.MonteCarlo with Numpy"""
+    set_log_level("INFO")
+    _run_monte_carlo_tests("numpy")
+
+
+def test_integrate_torch():
+    """Test the integrate function in integration.MonteCarlo with Torch"""
+    set_log_level("INFO")
+    enable_cuda()
+    # 32 bit float precision suffices for Monte Carlo tests
+    set_precision("float", backend="torch")
+    _run_monte_carlo_tests("torch")
+
+
+def test_integrate_jax():
+    """Test the integrate function in integration.MonteCarlo with Torch"""
+    set_log_level("INFO")
+    set_precision("float", backend="jax")
+    _run_monte_carlo_tests("jax")
+
+
+def test_integrate_tensorflow():
+    """Test the integrate function in integration.MonteCarlo with Tensorflow"""
+    set_log_level("INFO")
+    _run_monte_carlo_tests("tensorflow")
 
 
 if __name__ == "__main__":
     # used to run this test individually
-    test_integrate()
+    test_integrate_numpy()
+    test_integrate_torch()
+    test_integrate_jax()
+    test_integrate_tensorflow()

--- a/torchquad/tests/monte_carlo_test.py
+++ b/torchquad/tests/monte_carlo_test.py
@@ -6,6 +6,7 @@ from integration.monte_carlo import MonteCarlo
 from utils.enable_cuda import enable_cuda
 from utils.set_precision import set_precision
 from utils.set_log_level import set_log_level
+from integration_test_utils import compute_test_errors
 
 
 def test_integrate():
@@ -13,9 +14,6 @@ def test_integrate():
     set_log_level("INFO")
     enable_cuda()
     set_precision("double")
-
-    # Needs to happen after precision / device settings to avoid having some tensors intialized on cpu and some on GPU
-    from integration_test_utils import compute_test_errors
 
     mc = MonteCarlo()
 

--- a/torchquad/tests/monte_carlo_test.py
+++ b/torchquad/tests/monte_carlo_test.py
@@ -2,15 +2,13 @@ import sys
 
 sys.path.append("../")
 
+import pytest
+
 from integration.monte_carlo import MonteCarlo
 from utils.enable_cuda import enable_cuda
 from utils.set_precision import set_precision
 from utils.set_log_level import set_log_level
 from integration_test_utils import compute_integration_test_errors
-
-from tensorflow.python.ops.numpy_ops import np_config
-
-np_config.enable_numpy_behavior()
 
 
 def _run_monte_carlo_tests(backend):
@@ -87,12 +85,14 @@ def _run_monte_carlo_tests(backend):
 
 def test_integrate_numpy():
     """Test the integrate function in integration.MonteCarlo with Numpy"""
+    pytest.importorskip("numpy")
     set_log_level("INFO")
     _run_monte_carlo_tests("numpy")
 
 
 def test_integrate_torch():
     """Test the integrate function in integration.MonteCarlo with Torch"""
+    pytest.importorskip("torch")
     set_log_level("INFO")
     enable_cuda()
     # 32 bit float precision suffices for Monte Carlo tests
@@ -101,7 +101,8 @@ def test_integrate_torch():
 
 
 def test_integrate_jax():
-    """Test the integrate function in integration.MonteCarlo with Torch"""
+    """Test the integrate function in integration.MonteCarlo with JAX"""
+    pytest.importorskip("jax")
     set_log_level("INFO")
     set_precision("float", backend="jax")
     _run_monte_carlo_tests("jax")
@@ -109,6 +110,12 @@ def test_integrate_jax():
 
 def test_integrate_tensorflow():
     """Test the integrate function in integration.MonteCarlo with Tensorflow"""
+    pytest.importorskip("tensorflow")
+    from tensorflow.python.ops.numpy_ops import np_config
+
+    # The Tensorflow backend only works with numpy behaviour enabled.
+    np_config.enable_numpy_behavior()
+
     set_log_level("INFO")
     _run_monte_carlo_tests("tensorflow")
 

--- a/torchquad/tests/monte_carlo_test.py
+++ b/torchquad/tests/monte_carlo_test.py
@@ -2,16 +2,14 @@ import sys
 
 sys.path.append("../")
 
-import pytest
-
 from integration.monte_carlo import MonteCarlo
-from utils.enable_cuda import enable_cuda
-from utils.set_precision import set_precision
-from utils.set_log_level import set_log_level
-from integration_test_utils import compute_integration_test_errors
+from integration_test_utils import (
+    compute_integration_test_errors,
+    setup_test_for_backend,
+)
 
 
-def _run_monte_carlo_tests(backend):
+def _run_monte_carlo_tests(backend, _precision):
     """Test the integrate function in integration.MonteCarlo for the given backend."""
 
     mc = MonteCarlo()
@@ -83,41 +81,12 @@ def _run_monte_carlo_tests(backend):
         assert error < 26
 
 
-def test_integrate_numpy():
-    """Test the integrate function in integration.MonteCarlo with Numpy"""
-    pytest.importorskip("numpy")
-    set_log_level("INFO")
-    _run_monte_carlo_tests("numpy")
-
-
-def test_integrate_torch():
-    """Test the integrate function in integration.MonteCarlo with Torch"""
-    pytest.importorskip("torch")
-    set_log_level("INFO")
-    enable_cuda()
-    # 32 bit float precision suffices for Monte Carlo tests
-    set_precision("float", backend="torch")
-    _run_monte_carlo_tests("torch")
-
-
-def test_integrate_jax():
-    """Test the integrate function in integration.MonteCarlo with JAX"""
-    pytest.importorskip("jax")
-    set_log_level("INFO")
-    set_precision("float", backend="jax")
-    _run_monte_carlo_tests("jax")
-
-
-def test_integrate_tensorflow():
-    """Test the integrate function in integration.MonteCarlo with Tensorflow"""
-    pytest.importorskip("tensorflow")
-    from tensorflow.python.ops.numpy_ops import np_config
-
-    # The Tensorflow backend only works with numpy behaviour enabled.
-    np_config.enable_numpy_behavior()
-
-    set_log_level("INFO")
-    _run_monte_carlo_tests("tensorflow")
+test_integrate_numpy = setup_test_for_backend(_run_monte_carlo_tests, "numpy", "unused")
+test_integrate_torch = setup_test_for_backend(_run_monte_carlo_tests, "torch", "float")
+test_integrate_jax = setup_test_for_backend(_run_monte_carlo_tests, "jax", "float")
+test_integrate_tensorflow = setup_test_for_backend(
+    _run_monte_carlo_tests, "tensorflow", "float"
+)
 
 
 if __name__ == "__main__":

--- a/torchquad/tests/simpson_test.py
+++ b/torchquad/tests/simpson_test.py
@@ -8,56 +8,86 @@ from integration.simpson import Simpson
 from utils.enable_cuda import enable_cuda
 from utils.set_precision import set_precision
 from utils.set_log_level import set_log_level
-from integration_test_utils import compute_test_errors
+from integration_test_utils import run_example_functions
 
 
-def test_integrate():
-    """Tests the integrate function in integration.Simpson."""
-    set_log_level("INFO")
-    enable_cuda()
-    set_precision("double")
+def _run_simpson_tests(backend):
+    """Test the integrate function in integration.Simpson for the given backend."""
 
     simp = Simpson()
 
     # 1D Tests
     N = 100001
 
-    errors = compute_test_errors(simp.integrate, {"N": N, "dim": 1}, use_complex=True)
-    print("1D Simpson Test: Passed N =", N, "\n", "Errors: ", errors)
+    errors, funcs = run_example_functions(
+        simp.integrate, {"N": N, "dim": 1}, dim=1, use_complex=True, backend=backend
+    )
+    print(f"1D Simpson Test passed. N: {N}, backend: {backend}, Errors: {errors}")
+    # Polynomials up to degree 3 can be integrated almost exactly with Simpson.
+    for err, test_function in zip(errors, funcs):
+        assert test_function.get_order() > 3 or err < 3e-11
     for error in errors:
         assert error < 1e-7
 
     N = 3  # integration points, here 3 for order check (3 points should lead to almost 0 err for low order polynomials)
-    errors = compute_test_errors(simp.integrate, {"N": N, "dim": 1}, use_complex=True)
-    print("1D Simpson Test: Passed N =", N, "\n", "Errors: ", errors)
+    errors, funcs = run_example_functions(
+        simp.integrate, {"N": N, "dim": 1}, dim=1, use_complex=True, backend=backend
+    )
+    print(f"1D Simpson Test passed. N: {N}, backend: {backend}, Errors: {errors}")
     # All polynomials up to degree = 3 should be 0
     # If this breaks, check if test functions in integration_test_utils changed.
-    for error in errors[:3]:
-        assert error < 1e-15
+    for err, test_function in zip(errors, funcs):
+        assert test_function.get_order() > 3 or err < 1e-15
 
     # 3D Tests
     N = 1076890  # N = 102.5 per dim (will change to 101 if all works)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        errors = compute_test_errors(
-            simp.integrate, {"N": N, "dim": 3}, dim=3, use_complex=True
+        errors, funcs = run_example_functions(
+            simp.integrate, {"N": N, "dim": 3}, dim=3, use_complex=True, backend=backend
         )
-    print("3D Simpson Test: Passed N =", N, "\n", "Errors: ", errors)
-    for error in errors[:3]:
-        assert error < 1e-12
+    print(f"3D Simpson Test passed. N: {N}, backend: {backend}, Errors: {errors}")
+    for err, test_function in zip(errors, funcs):
+        assert test_function.get_order() > 3 or err < 1e-12
     for error in errors:
         assert error < 5e-6
 
     # 10D Tests
     N = 3 ** 10
-    errors = compute_test_errors(
-        simp.integrate, {"N": N, "dim": 10}, dim=10, use_complex=True
+    errors, funcs = run_example_functions(
+        simp.integrate, {"N": N, "dim": 10}, dim=10, use_complex=True, backend=backend
     )
-    print("10D Simpson Test: N =", N, "\n", errors)
+    print(f"10D Simpson Test passed. N: {N}, backend: {backend}, Errors: {errors}")
     for error in errors:
         assert error < 5e-9
 
 
+def test_integrate_numpy():
+    """Test the integrate function in integration.Simpson with Numpy"""
+    set_log_level("INFO")
+    _run_simpson_tests("numpy")
+
+
+def test_integrate_torch():
+    """Test the integrate function in integration.Simpson with Torch"""
+    set_log_level("INFO")
+    enable_cuda()
+    set_precision("double", backend="torch")
+    _run_simpson_tests("torch")
+
+
+def test_integrate_jax():
+    """Test the integrate function in integration.Simpson with Torch"""
+    set_log_level("INFO")
+    set_precision("double", backend="jax")
+    _run_simpson_tests("jax")
+
+
+# Skip tensorflow since it does not yet support double as global precision
+
+
 if __name__ == "__main__":
     # used to run this test individually
-    test_integrate()
+    test_integrate_numpy()
+    test_integrate_torch()
+    test_integrate_jax()

--- a/torchquad/tests/simpson_test.py
+++ b/torchquad/tests/simpson_test.py
@@ -8,7 +8,7 @@ from integration.simpson import Simpson
 from utils.enable_cuda import enable_cuda
 from utils.set_precision import set_precision
 from utils.set_log_level import set_log_level
-from integration_test_utils import run_example_functions
+from integration_test_utils import compute_integration_test_errors
 
 
 def _run_simpson_tests(backend):
@@ -19,7 +19,7 @@ def _run_simpson_tests(backend):
     # 1D Tests
     N = 100001
 
-    errors, funcs = run_example_functions(
+    errors, funcs = compute_integration_test_errors(
         simp.integrate, {"N": N, "dim": 1}, dim=1, use_complex=True, backend=backend
     )
     print(f"1D Simpson Test passed. N: {N}, backend: {backend}, Errors: {errors}")
@@ -30,7 +30,7 @@ def _run_simpson_tests(backend):
         assert error < 1e-7
 
     N = 3  # integration points, here 3 for order check (3 points should lead to almost 0 err for low order polynomials)
-    errors, funcs = run_example_functions(
+    errors, funcs = compute_integration_test_errors(
         simp.integrate, {"N": N, "dim": 1}, dim=1, use_complex=True, backend=backend
     )
     print(f"1D Simpson Test passed. N: {N}, backend: {backend}, Errors: {errors}")
@@ -43,7 +43,7 @@ def _run_simpson_tests(backend):
     N = 1076890  # N = 102.5 per dim (will change to 101 if all works)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        errors, funcs = run_example_functions(
+        errors, funcs = compute_integration_test_errors(
             simp.integrate, {"N": N, "dim": 3}, dim=3, use_complex=True, backend=backend
         )
     print(f"3D Simpson Test passed. N: {N}, backend: {backend}, Errors: {errors}")
@@ -54,7 +54,7 @@ def _run_simpson_tests(backend):
 
     # 10D Tests
     N = 3 ** 10
-    errors, funcs = run_example_functions(
+    errors, funcs = compute_integration_test_errors(
         simp.integrate, {"N": N, "dim": 10}, dim=10, use_complex=True, backend=backend
     )
     print(f"10D Simpson Test passed. N: {N}, backend: {backend}, Errors: {errors}")

--- a/torchquad/tests/simpson_test.py
+++ b/torchquad/tests/simpson_test.py
@@ -2,6 +2,7 @@ import sys
 
 sys.path.append("../")
 
+import pytest
 import warnings
 
 from integration.simpson import Simpson
@@ -64,12 +65,14 @@ def _run_simpson_tests(backend):
 
 def test_integrate_numpy():
     """Test the integrate function in integration.Simpson with Numpy"""
+    pytest.importorskip("numpy")
     set_log_level("INFO")
     _run_simpson_tests("numpy")
 
 
 def test_integrate_torch():
     """Test the integrate function in integration.Simpson with Torch"""
+    pytest.importorskip("torch")
     set_log_level("INFO")
     enable_cuda()
     set_precision("double", backend="torch")
@@ -77,7 +80,8 @@ def test_integrate_torch():
 
 
 def test_integrate_jax():
-    """Test the integrate function in integration.Simpson with Torch"""
+    """Test the integrate function in integration.Simpson with JAX"""
+    pytest.importorskip("jax")
     set_log_level("INFO")
     set_precision("double", backend="jax")
     _run_simpson_tests("jax")

--- a/torchquad/tests/simpson_test.py
+++ b/torchquad/tests/simpson_test.py
@@ -8,6 +8,7 @@ from integration.simpson import Simpson
 from utils.enable_cuda import enable_cuda
 from utils.set_precision import set_precision
 from utils.set_log_level import set_log_level
+from integration_test_utils import compute_test_errors
 
 
 def test_integrate():
@@ -15,9 +16,6 @@ def test_integrate():
     set_log_level("INFO")
     enable_cuda()
     set_precision("double")
-
-    # Needs to happen after precision / device settings to avoid having some tensors intialized on cpu and some on GPU
-    from integration_test_utils import compute_test_errors
 
     simp = Simpson()
 

--- a/torchquad/tests/simpson_test.py
+++ b/torchquad/tests/simpson_test.py
@@ -2,17 +2,16 @@ import sys
 
 sys.path.append("../")
 
-import pytest
 import warnings
 
 from integration.simpson import Simpson
-from utils.enable_cuda import enable_cuda
-from utils.set_precision import set_precision
-from utils.set_log_level import set_log_level
-from integration_test_utils import compute_integration_test_errors
+from integration_test_utils import (
+    compute_integration_test_errors,
+    setup_test_for_backend,
+)
 
 
-def _run_simpson_tests(backend):
+def _run_simpson_tests(backend, _precision):
     """Test the integrate function in integration.Simpson for the given backend."""
 
     simp = Simpson()
@@ -63,30 +62,9 @@ def _run_simpson_tests(backend):
         assert error < 5e-9
 
 
-def test_integrate_numpy():
-    """Test the integrate function in integration.Simpson with Numpy"""
-    pytest.importorskip("numpy")
-    set_log_level("INFO")
-    _run_simpson_tests("numpy")
-
-
-def test_integrate_torch():
-    """Test the integrate function in integration.Simpson with Torch"""
-    pytest.importorskip("torch")
-    set_log_level("INFO")
-    enable_cuda()
-    set_precision("double", backend="torch")
-    _run_simpson_tests("torch")
-
-
-def test_integrate_jax():
-    """Test the integrate function in integration.Simpson with JAX"""
-    pytest.importorskip("jax")
-    set_log_level("INFO")
-    set_precision("double", backend="jax")
-    _run_simpson_tests("jax")
-
-
+test_integrate_numpy = setup_test_for_backend(_run_simpson_tests, "numpy", "double")
+test_integrate_torch = setup_test_for_backend(_run_simpson_tests, "torch", "double")
+test_integrate_jax = setup_test_for_backend(_run_simpson_tests, "jax", "double")
 # Skip tensorflow since it does not yet support double as global precision
 
 

--- a/torchquad/tests/trapezoid_test.py
+++ b/torchquad/tests/trapezoid_test.py
@@ -7,53 +7,91 @@ from integration.trapezoid import Trapezoid
 from utils.enable_cuda import enable_cuda
 from utils.set_precision import set_precision
 from utils.set_log_level import set_log_level
-from integration_test_utils import compute_test_errors
+from integration_test_utils import run_example_functions
+
+# ~ from tensorflow.python.ops.numpy_ops import np_config
+
+# ~ np_config.enable_numpy_behavior()
 
 
-def test_integrate():
-    """Tests the integrate function in integration.Trapezoid."""
-    set_log_level("INFO")
-    enable_cuda()
-    set_precision("double")
+def _run_trapezoid_tests(backend):
+    """Test the integrate function in integration.Trapezoid for the given backend."""
 
     tp = Trapezoid()
-    N = 100000
 
     # 1D Tests
-    errors = compute_test_errors(tp.integrate, {"N": N, "dim": 1}, use_complex=True)
-    print("1D Trapezoid Test: Passed N =", N, "\n", "Errors: ", errors)
+    N = 100000
+    errors, funcs = run_example_functions(
+        tp.integrate, {"N": N, "dim": 1}, dim=1, use_complex=True, backend=backend
+    )
+    print(f"1D Trapezoid Test passed. N: {N}, backend: {backend}, Errors: {errors}")
+    # Polynomials up to degree 1 can be integrated almost exactly with Trapezoid.
+    for err, test_function in zip(errors, funcs):
+        assert test_function.get_order() > 1 or err < 2e-11
     for error in errors:
         assert error < 1e-5
 
     N = 2  # integration points, here 2 for order check (2 points should lead to almost 0 err for low order polynomials)
-    errors = compute_test_errors(tp.integrate, {"N": N, "dim": 1}, use_complex=True)
-    print("1D Trapezoid Test: Passed N =", N, "\n", "Errors: ", errors)
+    errors, funcs = run_example_functions(
+        tp.integrate, {"N": N, "dim": 1}, dim=1, use_complex=True, backend=backend
+    )
+    print(f"1D Trapezoid Test passed. N: {N}, backend: {backend}, Errors: {errors}")
     # All polynomials up to degree = 1 should be 0
     # If this breaks check if test functions in integration_test_utils changed.
+    for err, test_function in zip(errors, funcs):
+        assert test_function.get_order() > 1 or err < 1e-15
     for error in errors[:2]:
         assert error < 1e-15
 
     # 3D Tests
     N = 1000000
-    errors = compute_test_errors(
-        tp.integrate, {"N": N, "dim": 3}, dim=3, use_complex=True
+    errors, funcs = run_example_functions(
+        tp.integrate, {"N": N, "dim": 3}, dim=3, use_complex=True, backend=backend
     )
-    print("3D Trapezoid Test: Passed N =", N, "\n", "Errors: ", errors)
-    for error in errors[:2]:
-        assert error < 1e-12
+    print(f"3D Trapezoid Test passed. N: {N}, backend: {backend}, Errors: {errors}")
+    for err, test_function in zip(errors, funcs):
+        assert test_function.get_order() > 1 or err < 1e-12
     for error in errors:
         assert error < 6e-3
 
     # 10D Tests
     N = 10000
-    errors = compute_test_errors(
-        tp.integrate, {"N": N, "dim": 10}, dim=10, use_complex=True
+    errors, funcs = run_example_functions(
+        tp.integrate, {"N": N, "dim": 10}, dim=10, use_complex=True, backend=backend
     )
-    print("10D Trapezoid Test: Passed N =", N, "\n", "Errors: ", errors)
+    print(f"10D Trapezoid Test passed. N: {N}, backend: {backend}, Errors: {errors}")
+    for err, test_function in zip(errors, funcs):
+        assert test_function.get_order() > 1 or err < 1e-11
     for error in errors:
         assert error < 7000
 
 
+def test_integrate_numpy():
+    """Test the integrate function in integration.Trapezoid with Numpy"""
+    set_log_level("INFO")
+    _run_trapezoid_tests("numpy")
+
+
+def test_integrate_torch():
+    """Test the integrate function in integration.Trapezoid with Torch"""
+    set_log_level("INFO")
+    enable_cuda()
+    set_precision("double", backend="torch")
+    _run_trapezoid_tests("torch")
+
+
+def test_integrate_jax():
+    """Test the integrate function in integration.Trapezoid with Torch"""
+    set_log_level("INFO")
+    set_precision("double", backend="jax")
+    _run_trapezoid_tests("jax")
+
+
+# Skip tensorflow since it does not yet support double as global precision
+
+
 if __name__ == "__main__":
     # used to run this test individually
-    test_integrate()
+    test_integrate_numpy()
+    test_integrate_torch()
+    test_integrate_jax()

--- a/torchquad/tests/trapezoid_test.py
+++ b/torchquad/tests/trapezoid_test.py
@@ -7,6 +7,7 @@ from integration.trapezoid import Trapezoid
 from utils.enable_cuda import enable_cuda
 from utils.set_precision import set_precision
 from utils.set_log_level import set_log_level
+from integration_test_utils import compute_test_errors
 
 
 def test_integrate():
@@ -14,9 +15,6 @@ def test_integrate():
     set_log_level("INFO")
     enable_cuda()
     set_precision("double")
-
-    # Needs to happen after precision / device settings to avoid having some tensors intialized on cpu and some on GPU
-    from integration_test_utils import compute_test_errors
 
     tp = Trapezoid()
     N = 100000

--- a/torchquad/tests/trapezoid_test.py
+++ b/torchquad/tests/trapezoid_test.py
@@ -2,16 +2,13 @@ import sys
 
 sys.path.append("../")
 
+import pytest
 
 from integration.trapezoid import Trapezoid
 from utils.enable_cuda import enable_cuda
 from utils.set_precision import set_precision
 from utils.set_log_level import set_log_level
 from integration_test_utils import compute_integration_test_errors
-
-# ~ from tensorflow.python.ops.numpy_ops import np_config
-
-# ~ np_config.enable_numpy_behavior()
 
 
 def _run_trapezoid_tests(backend):
@@ -68,12 +65,14 @@ def _run_trapezoid_tests(backend):
 
 def test_integrate_numpy():
     """Test the integrate function in integration.Trapezoid with Numpy"""
+    pytest.importorskip("numpy")
     set_log_level("INFO")
     _run_trapezoid_tests("numpy")
 
 
 def test_integrate_torch():
     """Test the integrate function in integration.Trapezoid with Torch"""
+    pytest.importorskip("torch")
     set_log_level("INFO")
     enable_cuda()
     set_precision("double", backend="torch")
@@ -81,7 +80,8 @@ def test_integrate_torch():
 
 
 def test_integrate_jax():
-    """Test the integrate function in integration.Trapezoid with Torch"""
+    """Test the integrate function in integration.Trapezoid with JAX"""
+    pytest.importorskip("jax")
     set_log_level("INFO")
     set_precision("double", backend="jax")
     _run_trapezoid_tests("jax")

--- a/torchquad/tests/trapezoid_test.py
+++ b/torchquad/tests/trapezoid_test.py
@@ -7,7 +7,7 @@ from integration.trapezoid import Trapezoid
 from utils.enable_cuda import enable_cuda
 from utils.set_precision import set_precision
 from utils.set_log_level import set_log_level
-from integration_test_utils import run_example_functions
+from integration_test_utils import compute_integration_test_errors
 
 # ~ from tensorflow.python.ops.numpy_ops import np_config
 
@@ -21,7 +21,7 @@ def _run_trapezoid_tests(backend):
 
     # 1D Tests
     N = 100000
-    errors, funcs = run_example_functions(
+    errors, funcs = compute_integration_test_errors(
         tp.integrate, {"N": N, "dim": 1}, dim=1, use_complex=True, backend=backend
     )
     print(f"1D Trapezoid Test passed. N: {N}, backend: {backend}, Errors: {errors}")
@@ -32,7 +32,7 @@ def _run_trapezoid_tests(backend):
         assert error < 1e-5
 
     N = 2  # integration points, here 2 for order check (2 points should lead to almost 0 err for low order polynomials)
-    errors, funcs = run_example_functions(
+    errors, funcs = compute_integration_test_errors(
         tp.integrate, {"N": N, "dim": 1}, dim=1, use_complex=True, backend=backend
     )
     print(f"1D Trapezoid Test passed. N: {N}, backend: {backend}, Errors: {errors}")
@@ -45,7 +45,7 @@ def _run_trapezoid_tests(backend):
 
     # 3D Tests
     N = 1000000
-    errors, funcs = run_example_functions(
+    errors, funcs = compute_integration_test_errors(
         tp.integrate, {"N": N, "dim": 3}, dim=3, use_complex=True, backend=backend
     )
     print(f"3D Trapezoid Test passed. N: {N}, backend: {backend}, Errors: {errors}")
@@ -56,7 +56,7 @@ def _run_trapezoid_tests(backend):
 
     # 10D Tests
     N = 10000
-    errors, funcs = run_example_functions(
+    errors, funcs = compute_integration_test_errors(
         tp.integrate, {"N": N, "dim": 10}, dim=10, use_complex=True, backend=backend
     )
     print(f"10D Trapezoid Test passed. N: {N}, backend: {backend}, Errors: {errors}")

--- a/torchquad/tests/trapezoid_test.py
+++ b/torchquad/tests/trapezoid_test.py
@@ -2,16 +2,14 @@ import sys
 
 sys.path.append("../")
 
-import pytest
-
 from integration.trapezoid import Trapezoid
-from utils.enable_cuda import enable_cuda
-from utils.set_precision import set_precision
-from utils.set_log_level import set_log_level
-from integration_test_utils import compute_integration_test_errors
+from integration_test_utils import (
+    compute_integration_test_errors,
+    setup_test_for_backend,
+)
 
 
-def _run_trapezoid_tests(backend):
+def _run_trapezoid_tests(backend, _precision):
     """Test the integrate function in integration.Trapezoid for the given backend."""
 
     tp = Trapezoid()
@@ -63,30 +61,9 @@ def _run_trapezoid_tests(backend):
         assert error < 7000
 
 
-def test_integrate_numpy():
-    """Test the integrate function in integration.Trapezoid with Numpy"""
-    pytest.importorskip("numpy")
-    set_log_level("INFO")
-    _run_trapezoid_tests("numpy")
-
-
-def test_integrate_torch():
-    """Test the integrate function in integration.Trapezoid with Torch"""
-    pytest.importorskip("torch")
-    set_log_level("INFO")
-    enable_cuda()
-    set_precision("double", backend="torch")
-    _run_trapezoid_tests("torch")
-
-
-def test_integrate_jax():
-    """Test the integrate function in integration.Trapezoid with JAX"""
-    pytest.importorskip("jax")
-    set_log_level("INFO")
-    set_precision("double", backend="jax")
-    _run_trapezoid_tests("jax")
-
-
+test_integrate_numpy = setup_test_for_backend(_run_trapezoid_tests, "numpy", "double")
+test_integrate_torch = setup_test_for_backend(_run_trapezoid_tests, "torch", "double")
+test_integrate_jax = setup_test_for_backend(_run_trapezoid_tests, "jax", "double")
 # Skip tensorflow since it does not yet support double as global precision
 
 

--- a/torchquad/tests/vegas_test.py
+++ b/torchquad/tests/vegas_test.py
@@ -10,6 +10,7 @@ from integration.vegas import VEGAS
 from utils.enable_cuda import enable_cuda
 from utils.set_precision import set_precision
 from utils.set_log_level import set_log_level
+from integration_test_utils import compute_test_errors
 
 
 def test_integrate():
@@ -17,9 +18,6 @@ def test_integrate():
     set_log_level("INFO")
     enable_cuda()
     set_precision("double")
-
-    # Needs to happen after precision / device settings to avoid having some tensors intialized on cpu and some on GPU
-    from integration_test_utils import compute_test_errors
 
     vegas = VEGAS()
 

--- a/torchquad/tests/vegas_test.py
+++ b/torchquad/tests/vegas_test.py
@@ -10,7 +10,7 @@ from integration.vegas import VEGAS
 from utils.enable_cuda import enable_cuda
 from utils.set_precision import set_precision
 from utils.set_log_level import set_log_level
-from integration_test_utils import compute_test_errors
+from integration_test_utils import compute_integration_test_errors
 
 
 def test_integrate():
@@ -23,8 +23,12 @@ def test_integrate():
 
     # 1D Tests
     N = 10000
-    errors = compute_test_errors(
-        vegas.integrate, {"N": N, "dim": 1, "seed": 0}, use_complex=False
+    errors, _ = compute_integration_test_errors(
+        vegas.integrate,
+        {"N": N, "dim": 1, "seed": 0},
+        dim=1,
+        use_complex=False,
+        backend="torch",
     )
     print("1D VEGAS Test: Passed N =", N, "\n", "Errors: ", errors)
     for error in errors[:3]:
@@ -38,8 +42,12 @@ def test_integrate():
 
     # 3D Tests
     N = 10000
-    errors = compute_test_errors(
-        vegas.integrate, {"N": N, "dim": 3, "seed": 0}, dim=3, use_complex=False
+    errors, _ = compute_integration_test_errors(
+        vegas.integrate,
+        {"N": N, "dim": 3, "seed": 0},
+        dim=3,
+        use_complex=False,
+        backend="torch",
     )
     print("3D VEGAS Test: Passed N =", N, "\n", "Errors: ", errors)
     for error in errors:
@@ -47,8 +55,12 @@ def test_integrate():
 
     # 10D Tests
     N = 10000
-    errors = compute_test_errors(
-        vegas.integrate, {"N": N, "dim": 10, "seed": 0}, dim=10, use_complex=False
+    errors, _ = compute_integration_test_errors(
+        vegas.integrate,
+        {"N": N, "dim": 10, "seed": 0},
+        dim=10,
+        use_complex=False,
+        backend="torch",
     )
     print("10D VEGAS Test: Passed N =", N, "\n", "Errors: ", errors)
     for error in errors:


### PR DESCRIPTION
The first commit changes the test functions code and example function initialisations so that they work with other numerical backends (via autoray). 
The other commits change the tests of the respective integration rules so that they use other backends than only torch.
Related issue: #8