### PR TITLE
Enable CUDA by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,10 +147,7 @@ The full documentation can be found on [readthedocs](https://torchquad.readthedo
 # ideally allocate everything in torch on the GPU
 # and avoid non-torch function calls
 import torch 
-from torchquad import MonteCarlo, enable_cuda
-
-# Enable GPU support if available
-enable_cuda() 
+from torchquad import MonteCarlo
 
 # The function we want to integrate, in this example f(x0,x1) = sin(x0) + e^x1 for x0=[0,1] and x1=[-1,1]
 # Note that the function needs to support multiple evaluations at once (first dimension of x here)

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -16,10 +16,7 @@ Minimal working example
     # ideally allocate everything in torch on the GPU
     # and avoid non-torch function calls
     import torch 
-    from torchquad import MonteCarlo, enable_cuda
-
-    # Enable GPU support if available
-    enable_cuda() 
+    from torchquad import MonteCarlo
 
     # The function we want to integrate, in this example f(x0,x1) = sin(x0) + e^x1 for x0=[0,1] and x1=[-1,1]
     # Note that the function needs to support multiple evaluations at once (first dimension of x here)
@@ -111,20 +108,8 @@ Now let’s get started! First, the general imports:
     import torch
     torch.set_printoptions(precision=10) # Set displayed output precision to 10 digits
     
-    from torchquad import enable_cuda # Necessary to enable GPU support
     from torchquad import Trapezoid, Simpson, Boole, MonteCarlo, VEGAS # The available integrators
-    import torchquad
-
-.. code:: ipython3
-
-    enable_cuda() # Use this to enable GPU support 
-
-
-.. parsed-literal::
-
-    **Output:** Setting default tensor type to cuda.Float32 (CUDA is initialized).
-
-
+    import torchquad  # Initialize torchquad with CUDA support if possible
 
 
 One-dimensional integration
@@ -450,14 +435,12 @@ We selected the Trapezoid rule and the Monte Carlo method to showcase that getti
     import torch
     from torchquad.integration.monte_carlo import MonteCarlo
     from torchquad.integration.trapezoid import Trapezoid
-    from torchquad.utils.enable_cuda import enable_cuda
     from torchquad.utils.set_precision import set_precision
 
     def test_function(x):
         """V shaped test function."""
         return 2 * torch.abs(x)
 
-    enable_cuda()
     set_precision("double")
     N = 99997 # Number of iterations
     torch.manual_seed(0)  # We have to seed torch to get reproducible results

--- a/torchquad/__init__.py
+++ b/torchquad/__init__.py
@@ -38,4 +38,5 @@ __all__ = [
 ]
 
 set_log_level(os.environ.get("TORCHQUAD_LOG_LEVEL", "INFO"))
+enable_cuda()
 logger.info("Initializing torchquad.")

--- a/torchquad/__init__.py
+++ b/torchquad/__init__.py
@@ -1,10 +1,6 @@
 import os
 from loguru import logger
 
-# Set main device by default to cpu if no other choice was made before
-if "TORCH_DEVICE" not in os.environ:
-    os.environ["TORCH_DEVICE"] = "cpu"
-
 # TODO: Currently this is the way to expose to the docs
 # hopefully changes with setup.py
 from .integration.integration_grid import IntegrationGrid

--- a/torchquad/utils/enable_cuda.py
+++ b/torchquad/utils/enable_cuda.py
@@ -6,7 +6,7 @@ from .set_precision import set_precision
 
 
 def enable_cuda(device=0, data_type="float"):
-    """This function will set the default device to CUDA if possible. Call before declaring any variables!
+    """This function sets torch's default device to CUDA if possible. Call before declaring any variables!
     The default precision can be set here initially, or using set_precision later.
 
     Args:

--- a/torchquad/utils/enable_cuda.py
+++ b/torchquad/utils/enable_cuda.py
@@ -1,5 +1,4 @@
 import torch
-import os
 from loguru import logger
 
 from .set_precision import set_precision
@@ -14,7 +13,6 @@ def enable_cuda(device=0, data_type="float"):
         data_type (string, optional): Data type to use, either "float" or "double". Defaults to "float".
     """
     if torch.cuda.is_available():
-        os.environ["TORCH_DEVICE"] = "cuda:" + str(device)
         logger.info("PyTorch VERSION: " + str(torch.__version__))
         logger.info("CUDNN VERSION: " + str(torch.backends.cudnn.version()))
         logger.info("Number of CUDA Devices: " + str(torch.cuda.device_count()))


### PR DESCRIPTION
This only affects the torch backend. `enable_cuda` is still needed in the tests where `__init__.py` is not executed.

CUDA can be disabled with an environment variable if needed:
```sh
CUDA_VISIBLE_DEVICES= python3 -c "from torchquad import enable_cuda; enable_cuda()"
```