### PR TITLE
float and double precision for numpy and tensorflow 

### DIFF
--- a/torchquad/integration/integration_grid.py
+++ b/torchquad/integration/integration_grid.py
@@ -3,7 +3,11 @@ from autoray import infer_backend
 from time import perf_counter
 from loguru import logger
 
-from .utils import _linspace_with_grads, _check_integration_domain
+from .utils import (
+    _linspace_with_grads,
+    _check_integration_domain,
+    _setup_integration_domain,
+)
 
 
 class IntegrationGrid:
@@ -25,7 +29,9 @@ class IntegrationGrid:
         start = perf_counter()
         self._check_inputs(N, integration_domain)
         if infer_backend(integration_domain) == "builtins":
-            integration_domain = anp.array(integration_domain, like="torch")
+            integration_domain = _setup_integration_domain(
+                len(integration_domain), integration_domain, backend="torch"
+            )
         self._dim = integration_domain.shape[0]
 
         # TODO Add that N can be different for each dimension

--- a/torchquad/integration/monte_carlo.py
+++ b/torchquad/integration/monte_carlo.py
@@ -47,14 +47,17 @@ class MonteCarlo(BaseIntegrator):
         self._integration_domain = _setup_integration_domain(
             dim, integration_domain, backend
         )
-        rng = _RNG(backend=infer_backend(self._integration_domain), seed=seed)
+        backend = infer_backend(self._integration_domain)
+        rng = _RNG(backend=backend, seed=seed)
 
         logger.debug("Picking random sampling points")
         sample_points = []
         for d in range(dim):
             scale = self._integration_domain[d, 1] - self._integration_domain[d, 0]
             offset = self._integration_domain[d, 0]
-            sample_points.append(rng.uniform(size=[N]) * scale + offset)
+            sample_points.append(
+                rng.uniform(size=[N], dtype=scale.dtype) * scale + offset
+            )
         # FIXME: Is there a performance difference when initializing it
         # with zero instead of stacking it?
         sample_points = anp.stack(sample_points, axis=1, like=self._integration_domain)
@@ -68,5 +71,8 @@ class MonteCarlo(BaseIntegrator):
 
         # Integral = V / N * sum(func values)
         integral = volume * anp.sum(function_values) / N
+        # Numpy automatically casts to float64 when dividing by N
+        if backend == "numpy" and function_values.dtype != integral.dtype:
+            integral = integral.astype(function_values.dtype)
         logger.info("Computed integral was " + str(integral))
         return integral

--- a/torchquad/integration/utils.py
+++ b/torchquad/integration/utils.py
@@ -9,7 +9,7 @@ from autoray import numpy as anp
 from autoray import infer_backend, get_dtype_name
 from loguru import logger
 
-from utils.set_precision import torchquad_default_dtypes
+from utils.set_precision import _get_precision
 
 
 def _linspace_with_grads(start, stop, N, requires_grad):
@@ -65,7 +65,7 @@ def _setup_integration_domain(dim, integration_domain, backend):
         integration_domain = [
             [float(b) for b in bounds] for bounds in integration_domain
         ]
-        dtype_arg = torchquad_default_dtypes.get(backend, None)
+        dtype_arg = _get_precision(backend)
         if dtype_arg is not None:
             # For Numpy and Tensorflow there is no global dtype, so set the
             # configured default dtype here

--- a/torchquad/integration/utils.py
+++ b/torchquad/integration/utils.py
@@ -2,13 +2,15 @@
 import sys
 from pathlib import Path
 
-# import path required for torchquad_default_dtypes
+# Change the path to import from the parent folder.
+# A relative import currently does not work when executing the tests.
 sys.path.append(str(Path(__file__).absolute().parent.parent))
 
 from autoray import numpy as anp
 from autoray import infer_backend, get_dtype_name
 from loguru import logger
 
+# from ..utils.set_precision import _get_precision
 from utils.set_precision import _get_precision
 
 

--- a/torchquad/tests/boole_test.py
+++ b/torchquad/tests/boole_test.py
@@ -54,7 +54,9 @@ def _run_boole_tests(backend, _precision):
 test_integrate_numpy = setup_test_for_backend(_run_boole_tests, "numpy", "double")
 test_integrate_torch = setup_test_for_backend(_run_boole_tests, "torch", "double")
 test_integrate_jax = setup_test_for_backend(_run_boole_tests, "jax", "double")
-# Skip tensorflow since it does not yet support double as global precision
+test_integrate_tensorflow = setup_test_for_backend(
+    _run_boole_tests, "tensorflow", "double"
+)
 
 
 if __name__ == "__main__":
@@ -62,3 +64,4 @@ if __name__ == "__main__":
     test_integrate_numpy()
     test_integrate_torch()
     test_integrate_jax()
+    test_integrate_tensorflow()

--- a/torchquad/tests/integration_test_utils.py
+++ b/torchquad/tests/integration_test_utils.py
@@ -91,12 +91,14 @@ def get_test_functions(dim, backend):
             # e^x+e^y+e^z
             Exponential(
                 27 * (np.exp(3) - 1) / np.exp(2),
+                dim=3,
                 domain=[[-2, 1], [-2, 1], [-2, 1]],
                 is_complex=False,
                 backend=backend,
             ),
             Sinusoid(
                 24 * np.sin(1) ** 2,
+                dim=3,
                 domain=[[0, 2], [0, 2], [0, 2]],
                 is_complex=False,
                 backend=backend,
@@ -104,6 +106,7 @@ def get_test_functions(dim, backend):
             # e^x+e^y+e^z
             Exponential(
                 1.756,
+                dim=3,
                 domain=[[-0.05, 0.1], [-0.25, 0.2], [-np.exp(1), np.exp(1)]],
                 is_complex=False,
                 backend=backend,
@@ -214,11 +217,8 @@ def setup_test_for_backend(test_func, backend, precision):
         set_log_level("INFO")
         if backend == "torch":
             enable_cuda()
-        if precision is not None and backend in ["torch", "jax"]:
+        if precision is not None:
             set_precision(precision, backend=backend)
-        assert not (backend == "numpy" and precision == "float") and not (
-            backend == "tensorflow" and precision == "double"
-        )
         if backend == "tensorflow":
             from tensorflow.python.ops.numpy_ops import np_config
 

--- a/torchquad/tests/integration_test_utils.py
+++ b/torchquad/tests/integration_test_utils.py
@@ -197,13 +197,13 @@ def compute_integration_test_errors(
 
 def setup_test_for_backend(test_func, backend, precision):
     """
-    Execute a test function with the given numerical backend.
+    Create a function to execute a test function with the given numerical backend.
     If the backend is not installed, skip the test.
 
     Args:
         test_func (function(backend, precision)): The function which runs tests
         backend (string): The numerical backend
-        precision ("float" or "double"): Floating point precision
+        precision ("float", "double" or None): Floating point precision. If None, the global precision is not changed.
 
     Returns:
         function: A test function for Pytest
@@ -214,7 +214,7 @@ def setup_test_for_backend(test_func, backend, precision):
         set_log_level("INFO")
         if backend == "torch":
             enable_cuda()
-        if backend in ["torch", "jax"]:
+        if precision is not None and backend in ["torch", "jax"]:
             set_precision(precision, backend=backend)
         assert not (backend == "numpy" and precision == "float") and not (
             backend == "tensorflow" and precision == "double"
@@ -224,6 +224,8 @@ def setup_test_for_backend(test_func, backend, precision):
 
             # The Tensorflow backend only works with numpy behaviour enabled.
             np_config.enable_numpy_behavior()
+        if precision is None:
+            return test_func(backend)
         return test_func(backend, precision)
 
     return func

--- a/torchquad/tests/integrator_types_test.py
+++ b/torchquad/tests/integrator_types_test.py
@@ -54,14 +54,6 @@ def _run_simple_integrations(backend):
         [None, "float32", "float64"],
         zip(integrators_all, Ns_all),
     ):
-        # Numpy and Tensorflow don't support the configuration of their default
-        # dtype.
-        # They always default to float64 (Numpy) and float32 (Tensorflow).
-        if dtype_arg is None and (backend, dtype_global) in [
-            ("numpy", "float32"),
-            ("tensorflow", "float64"),
-        ]:
-            continue
         # JAX ignores the dtype argument when an array is created and always
         # uses the global precision.
         if (backend, dtype_global, dtype_arg) in [
@@ -70,10 +62,9 @@ def _run_simple_integrations(backend):
         ]:
             continue
 
-        # Set the global precision if the backend supports it
-        if backend in ["torch", "jax"]:
-            precision = {"float64": "double", "float32": "float"}[dtype_global]
-            set_precision(precision, backend=backend)
+        # Set the global precision
+        precision = {"float64": "double", "float32": "float"}[dtype_global]
+        set_precision(precision, backend=backend)
 
         integration_domain = [[0.0, 1.0], [-2.0, 0.0]]
         if dtype_arg is not None:

--- a/torchquad/tests/integrator_types_test.py
+++ b/torchquad/tests/integrator_types_test.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Additional integration tests to check if dtypes, shapes and similar
+backend-specific properties
+"""
+import sys
+
+sys.path.append("../")
+
+from autoray import numpy as anp
+from autoray import infer_backend, get_dtype_name, to_backend_dtype
+from itertools import product
+
+from integration.trapezoid import Trapezoid
+from integration.simpson import Simpson
+from integration.boole import Boole
+from integration.monte_carlo import MonteCarlo
+from utils.set_precision import set_precision
+from integration_test_utils import setup_test_for_backend
+
+
+# Setup for tensorflow so that Newton Cotes works
+from tensorflow.python.ops.numpy_ops import np_config
+
+np_config.enable_numpy_behavior()
+
+
+def _run_simple_integrations(backend):
+    """
+    Integrate a simple 2D constant function to check the following:
+    * The integrators do not crash with the numerical backend
+    * The evaluation points have the correct backend, dtype and shape
+    * The integration_domain argument dtype takes precedence over a globally
+      configured dtype
+    * The globally configured dtype or the backend's default dtype is used if
+      the integration_domain argument is a list
+    * MonteCarlo and the Newton Cotes composite integrators integrate a
+      constant function (almost) exactly.
+    """
+    integrators_all = [Trapezoid(), Simpson(), Boole(), MonteCarlo()]
+    Ns_all = [13 ** 2, 13 ** 2, 13 ** 2, 20]
+
+    expected_dtype_name = None
+
+    # Test only integrand output dtypes which are the same as the input dtype
+    def fn_const(x):
+        assert infer_backend(x) == backend
+        assert get_dtype_name(x) == expected_dtype_name
+        assert len(x.shape) == 2 and x.shape[1] == 2
+        return 0.0 * x[:, 0] - 2.0
+
+    for dtype_global, dtype_arg, (integrator, N) in product(
+        ["float32", "float64"],
+        [None, "float32", "float64"],
+        zip(integrators_all, Ns_all),
+    ):
+        # Numpy and Tensorflow don't support the configuration of their default
+        # dtype.
+        # They always default to float64 (Numpy) and float32 (Tensorflow).
+        if dtype_arg is None and (backend, dtype_global) in [
+            ("numpy", "float32"),
+            ("tensorflow", "float64"),
+        ]:
+            continue
+        # JAX ignores the dtype argument when an array is created and always
+        # uses the global precision.
+        if (backend, dtype_global, dtype_arg) in [
+            ("jax", "float32", "float64"),
+            ("jax", "float64", "float32"),
+        ]:
+            continue
+
+        # Set the global precision if the backend supports it
+        if backend in ["torch", "jax"]:
+            precision = {"float64": "double", "float32": "float"}[dtype_global]
+            set_precision(precision, backend=backend)
+
+        integration_domain = [[0.0, 1.0], [-2.0, 0.0]]
+        if dtype_arg is not None:
+            # Set the integration_domain dtype which should have higher priority
+            # than the global dtype
+            integration_domain = anp.array(
+                integration_domain,
+                dtype=to_backend_dtype(dtype_arg, like=backend),
+                like=backend,
+            )
+            assert infer_backend(integration_domain) == backend
+            assert get_dtype_name(integration_domain) == dtype_arg
+            expected_dtype_name = dtype_arg
+        else:
+            expected_dtype_name = dtype_global
+
+        integrator_name = type(integrator).__name__
+        print(
+            f"[2mTesting {integrator_name} with {backend}, argument dtype"
+            f" {dtype_arg}, global/default dtype {dtype_global}[m"
+        )
+        result = integrator.integrate(
+            fn=fn_const,
+            dim=2,
+            N=N,
+            integration_domain=integration_domain,
+            backend=backend,
+        )
+        assert infer_backend(result) == backend
+        assert get_dtype_name(result) == expected_dtype_name
+        assert anp.abs(result - (-4.0)) < 1e-5
+
+
+test_integrate_numpy = setup_test_for_backend(_run_simple_integrations, "numpy", None)
+test_integrate_torch = setup_test_for_backend(_run_simple_integrations, "torch", None)
+test_integrate_jax = setup_test_for_backend(_run_simple_integrations, "jax", None)
+test_integrate_tensorflow = setup_test_for_backend(
+    _run_simple_integrations, "tensorflow", None
+)
+
+
+if __name__ == "__main__":
+    try:
+        test_integrate_numpy()
+        test_integrate_torch()
+        test_integrate_jax()
+        test_integrate_tensorflow()
+    except KeyboardInterrupt:
+        pass

--- a/torchquad/tests/monte_carlo_test.py
+++ b/torchquad/tests/monte_carlo_test.py
@@ -81,7 +81,7 @@ def _run_monte_carlo_tests(backend, _precision):
         assert error < 26
 
 
-test_integrate_numpy = setup_test_for_backend(_run_monte_carlo_tests, "numpy", "unused")
+test_integrate_numpy = setup_test_for_backend(_run_monte_carlo_tests, "numpy", "float")
 test_integrate_torch = setup_test_for_backend(_run_monte_carlo_tests, "torch", "float")
 test_integrate_jax = setup_test_for_backend(_run_monte_carlo_tests, "jax", "float")
 test_integrate_tensorflow = setup_test_for_backend(

--- a/torchquad/tests/simpson_test.py
+++ b/torchquad/tests/simpson_test.py
@@ -52,6 +52,12 @@ def _run_simpson_tests(backend, _precision):
     for error in errors:
         assert error < 5e-6
 
+    # Tensorflow crashes with an Op:StridedSlice UnimplementedError with 10
+    # dimensions
+    if backend == "tensorflow":
+        print("Skipping tensorflow 10D tests")
+        return
+
     # 10D Tests
     N = 3 ** 10
     errors, funcs = compute_integration_test_errors(
@@ -65,7 +71,9 @@ def _run_simpson_tests(backend, _precision):
 test_integrate_numpy = setup_test_for_backend(_run_simpson_tests, "numpy", "double")
 test_integrate_torch = setup_test_for_backend(_run_simpson_tests, "torch", "double")
 test_integrate_jax = setup_test_for_backend(_run_simpson_tests, "jax", "double")
-# Skip tensorflow since it does not yet support double as global precision
+test_integrate_tensorflow = setup_test_for_backend(
+    _run_simpson_tests, "tensorflow", "double"
+)
 
 
 if __name__ == "__main__":
@@ -73,3 +81,4 @@ if __name__ == "__main__":
     test_integrate_numpy()
     test_integrate_torch()
     test_integrate_jax()
+    test_integrate_tensorflow()

--- a/torchquad/tests/trapezoid_test.py
+++ b/torchquad/tests/trapezoid_test.py
@@ -49,6 +49,12 @@ def _run_trapezoid_tests(backend, _precision):
     for error in errors:
         assert error < 6e-3
 
+    # Tensorflow crashes with an Op:StridedSlice UnimplementedError with 10
+    # dimensions
+    if backend == "tensorflow":
+        print("Skipping tensorflow 10D tests")
+        return
+
     # 10D Tests
     N = 10000
     errors, funcs = compute_integration_test_errors(
@@ -64,7 +70,9 @@ def _run_trapezoid_tests(backend, _precision):
 test_integrate_numpy = setup_test_for_backend(_run_trapezoid_tests, "numpy", "double")
 test_integrate_torch = setup_test_for_backend(_run_trapezoid_tests, "torch", "double")
 test_integrate_jax = setup_test_for_backend(_run_trapezoid_tests, "jax", "double")
-# Skip tensorflow since it does not yet support double as global precision
+test_integrate_tensorflow = setup_test_for_backend(
+    _run_trapezoid_tests, "tensorflow", "double"
+)
 
 
 if __name__ == "__main__":
@@ -72,3 +80,4 @@ if __name__ == "__main__":
     test_integrate_numpy()
     test_integrate_torch()
     test_integrate_jax()
+    test_integrate_tensorflow()

--- a/torchquad/tests/utils_integration_test.py
+++ b/torchquad/tests/utils_integration_test.py
@@ -3,7 +3,7 @@ import sys
 sys.path.append("../")
 
 from autoray import numpy as anp
-from autoray import infer_backend, get_dtype_name, to_numpy
+from autoray import infer_backend, get_dtype_name, to_backend_dtype, to_numpy
 import importlib
 import pytest
 import warnings
@@ -58,6 +58,9 @@ def _run_linspace_with_grads_tests(dtype_name, backend, requires_grad):
     Test _linspace_with_grads with the given dtype, numerical backend and
     requires_grad argument
     """
+    if requires_grad and backend != "torch":
+        # Currently only torch needs the requires_grad case distinction
+        return
     print(
         f"Testing _linspace_with_grads; backend: {backend}, requires_grad:"
         f" {requires_grad}, precision: {dtype_name}"
@@ -137,12 +140,14 @@ def _run_RNG_tests(dtype_name, backend):
     * With different seeds, different numbers should be generated
     * If seed is None / omitted, the RNG should be randomly seeded
     """
+    backend_dtype = to_backend_dtype(dtype_name, like=backend)
+    size = [3, 9]
     generateds = [
-        _RNG(backend, 547).uniform(size=[3, 9]),
-        _RNG(backend, None).uniform(size=[3, 9]),
-        _RNG(backend, 547).uniform(size=[3, 9]),
-        _RNG(backend).uniform(size=[3, 9]),
-        _RNG(backend, 42).uniform(size=[3, 9]),
+        _RNG(backend, 547).uniform(size=size, dtype=backend_dtype),
+        _RNG(backend, None).uniform(size=size, dtype=backend_dtype),
+        _RNG(backend, 547).uniform(size=size, dtype=backend_dtype),
+        _RNG(backend).uniform(size=size, dtype=backend_dtype),
+        _RNG(backend, 42).uniform(size=size, dtype=backend_dtype),
     ]
     numpy_arrs = list(map(to_numpy, generateds))
 


### PR DESCRIPTION
# Description

* A small bugfix in `integration_grid.py`
* Pass a dtype to `rng.uniform` and use the input argument's dtype in `_linspace_with_grads` so that other precisions than float32 can be used with Numpy and Tensorflow. 
* Add an ~global dict~ environment variable for a default precision used when `integration_domain` is a list
* Add a new test to check all combinations of backend, integrator, argument dtype and global dtype
* Change all tests so that they use Numpy and Tensorflow precisions

If the integrand function return value has another precision than the `integration_domain` (or global) precision, the resulting precision of the calculated integral value is undefined. This is the same behaviour as before the changes.

I don't know if an environment variable is a good choice for a global torchquad configuration here. 
When I tried it with a global python dict variable and executed the benchmarking script which changes the dict's values in `set_precision`, the changed values were missing in `_setup_integration_domain`; this problem doesn't happen with an environment variable.

## Resolved Issues

- [x] fixes #6
- [x] closes #3