### PR TITLE
Support gradient calculation and JIT compilation

### DIFF
--- a/torchquad/integration/integration_grid.py
+++ b/torchquad/integration/integration_grid.py
@@ -3,7 +3,7 @@ from autoray import infer_backend
 from time import perf_counter
 from loguru import logger
 
-from .utils import _linspace_with_grads
+from .utils import _linspace_with_grads, _check_integration_domain
 
 
 class IntegrationGrid:
@@ -24,9 +24,9 @@ class IntegrationGrid:
         """
         start = perf_counter()
         self._check_inputs(N, integration_domain)
-        self._dim = len(integration_domain)
         if infer_backend(integration_domain) == "builtins":
             integration_domain = anp.array(integration_domain, like="torch")
+        self._dim = integration_domain.shape[0]
 
         # TODO Add that N can be different for each dimension
         # A rounding error occurs for certain numbers with certain powers,
@@ -81,10 +81,7 @@ class IntegrationGrid:
         """Used to check input validity"""
 
         logger.debug("Checking inputs to IntegrationGrid.")
-        dim = len(integration_domain)
-
-        if dim < 1:
-            raise ValueError("len(integration_domain) needs to be 1 or larger.")
+        dim = _check_integration_domain(integration_domain)
 
         if N < 2:
             raise ValueError("N has to be > 1.")
@@ -97,19 +94,3 @@ class IntegrationGrid:
                 N,
                 " points. Too few points per dimension.",
             )
-
-        for bounds in integration_domain:
-            if len(bounds) != 2:
-                raise ValueError(
-                    bounds,
-                    " in ",
-                    integration_domain,
-                    " does not specify a valid integration bound.",
-                )
-            if bounds[0] > bounds[1]:
-                raise ValueError(
-                    bounds,
-                    " in ",
-                    integration_domain,
-                    " does not specify a valid integration bound.",
-                )

--- a/torchquad/tests/utils_integration_test.py
+++ b/torchquad/tests/utils_integration_test.py
@@ -119,9 +119,9 @@ def _run_setup_integration_domain_tests(dtype_name, backend):
     assert domain.dtype == custom_domain.dtype
 
     # Tests for invalid arguments
-    with pytest.raises(ValueError, match=r".* domain don't match.*"):
+    with pytest.raises(ValueError, match=r".*domain.*"):
         _setup_integration_domain(3, [[0, 1.0], [1, 2.0]], backend)
-    with pytest.raises(ValueError, match=r".* domain don't match.*"):
+    with pytest.raises(ValueError, match=r".*domain.*"):
         _setup_integration_domain(3, custom_domain, "unused")
 
 


### PR DESCRIPTION
I replaced `len()` with `.shape[0]` and changed the `integration_domain` argument validity check so that `tf.Variable` can be used as `integration_domain` and the boundary value checks are skipped if the values are not concrete, which can happen when compiling the function.
JIT compilation and gradient calculation works with JAX, Torch and Tensorflow.