### PR TITLE
Split NewtonCotes and MonteCarlo integration into three steps

### DIFF
--- a/torchquad/__init__.py
+++ b/torchquad/__init__.py
@@ -10,6 +10,8 @@ from .integration.simpson import Simpson
 from .integration.boole import Boole
 from .integration.vegas import VEGAS
 
+from .integration.utils import RNG
+
 from .plots.plot_convergence import plot_convergence
 from .plots.plot_runtime import plot_runtime
 
@@ -25,6 +27,7 @@ __all__ = [
     "Simpson",
     "Boole",
     "VEGAS",
+    "RNG",
     "plot_convergence",
     "plot_runtime",
     "enable_cuda",

--- a/torchquad/integration/base_integrator.py
+++ b/torchquad/integration/base_integrator.py
@@ -30,14 +30,29 @@ class BaseIntegrator:
         )
 
     def _eval(self, points):
-        """Evaluates the function at the passed points and updates nr_of_evals
+        """Call evaluate_integrand to evaluate self._fn function at the passed points and update self._nr_of_evals
 
         Args:
             points (backend tensor): Integration points
         """
-        num_points = points.shape[0]
+        result, num_points = self.evaluate_integrand(self._fn, points)
         self._nr_of_fevals += num_points
-        result = self._fn(points)
+        return result
+
+    @staticmethod
+    def evaluate_integrand(fn, points):
+        """Evaluate the integrand function at the passed points
+
+        Args:
+            fn (function): Integrand function
+            points (backend tensor): Integration points
+
+        Returns:
+            backend tensor: Integrand function output
+            int: Number of evaluated points
+        """
+        num_points = points.shape[0]
+        result = fn(points)
         if infer_backend(result) != infer_backend(points):
             warnings.warn(
                 "The passed function's return value has a different numerical backend than the passed points. Will try to convert. Note that this may be slow as it results in memory transfers between CPU and GPU, if torchquad uses the GPU."
@@ -52,9 +67,10 @@ class BaseIntegrator:
                 f"where first dimension matches length of passed elements. "
             )
 
-        return result
+        return result, num_points
 
-    def _check_inputs(self, dim=None, N=None, integration_domain=None):
+    @staticmethod
+    def _check_inputs(dim=None, N=None, integration_domain=None):
         """Used to check input validity
 
         Args:

--- a/torchquad/integration/boole.py
+++ b/torchquad/integration/boole.py
@@ -2,12 +2,10 @@ from autoray import numpy as anp
 import warnings
 from loguru import logger
 
-from .base_integrator import BaseIntegrator
-from .integration_grid import IntegrationGrid
-from .utils import _setup_integration_domain
+from .newton_cotes import NewtonCotes
 
 
-class Boole(BaseIntegrator):
+class Boole(NewtonCotes):
 
     """Boole's rule. See https://en.wikipedia.org/wiki/Newton%E2%80%93Cotes_formulas#Closed_Newton%E2%80%93Cotes_formulas ."""
 
@@ -27,46 +25,18 @@ class Boole(BaseIntegrator):
         Returns:
             float: integral value
         """
+        return super().integrate(fn, dim, N, integration_domain, backend)
 
-        # If N is unspecified, set N to 5 points per dimension
-        if N is None:
-            N = 5 ** dim
+    @staticmethod
+    def _apply_composite_rule(cur_dim_areas, dim, hs):
+        """Apply composite Boole quadrature.
 
-        self._integration_domain = _setup_integration_domain(
-            dim, integration_domain, backend
-        )
-        self._check_inputs(dim=dim, N=N, integration_domain=self._integration_domain)
-        N = self._adjust_N(dim=dim, N=N)
-
-        self._dim = dim
-        self._fn = fn
-
-        logger.debug(
-            "Using Boole for integrating a fn with a total of "
-            + str(N)
-            + " points over "
-            + str(self._integration_domain)
-            + "."
-        )
-
-        # Create grid and assemble evaluation points
-        self._grid = IntegrationGrid(N, self._integration_domain)
-
-        logger.debug("Evaluating integrand on the grid.")
-        function_values = self._eval(self._grid.points)
-
-        # Reshape the output to be [N,N,...] points instead of [dim*N] points
-        function_values = function_values.reshape([self._grid._N] * dim)
-
-        logger.debug("Computing areas.")
-
-        # This will contain the Simpson's areas per dimension
-        cur_dim_areas = function_values
-
+        cur_dim_areas will contain the areas per dimension
+        """
         # We collapse dimension by dimension
         for cur_dim in range(dim):
             cur_dim_areas = (
-                self._grid.h[cur_dim]
+                hs[cur_dim]
                 / 22.5
                 * (
                     7 * cur_dim_areas[..., 0:-4][..., ::4]
@@ -77,11 +47,15 @@ class Boole(BaseIntegrator):
                 )
             )
             cur_dim_areas = anp.sum(cur_dim_areas, axis=dim - cur_dim - 1)
-        logger.info("Computed integral was " + str(cur_dim_areas) + ".")
-
         return cur_dim_areas
 
-    def _adjust_N(self, dim, N):
+    @staticmethod
+    def _get_minimal_N(dim):
+        """Get the minimal number of points N for the integrator rule"""
+        return 5 ** dim
+
+    @staticmethod
+    def _adjust_N(dim, N):
         """Adjusts the total number of points to a valid number, i.e. N satisfies N^(1/dim) - 1 % 4 == 0.
 
         Args:

--- a/torchquad/integration/integration_grid.py
+++ b/torchquad/integration/integration_grid.py
@@ -40,13 +40,11 @@ class IntegrationGrid:
         # i.e. int(3.99999...) -> 3, a little error term is useful
         self._N = int(N ** (1.0 / self._dim) + 1e-8)  # convert to points per dim
 
-        logger.debug(
-            "Creating "
-            + str(self._dim)
-            + "-dimensional integration grid with "
-            + str(N)
-            + " points over"
-            + str(integration_domain),
+        logger.opt(lazy=True).debug(
+            "Creating {dim}-dimensional integration grid with {N} points over {dom}",
+            dim=lambda: str(self._dim),
+            N=lambda: str(N),
+            dom=lambda: str(integration_domain),
         )
 
         # Check if domain requires gradient
@@ -71,7 +69,7 @@ class IntegrationGrid:
             like=integration_domain,
         )
 
-        logger.debug("Grid mesh width is " + str(self.h))
+        logger.opt(lazy=True).debug("Grid mesh width is {h}", h=lambda: str(self.h))
 
         # Get grid points
         points = anp.meshgrid(*grid_1d)

--- a/torchquad/integration/monte_carlo.py
+++ b/torchquad/integration/monte_carlo.py
@@ -3,7 +3,7 @@ from autoray import infer_backend
 from loguru import logger
 
 from .base_integrator import BaseIntegrator
-from .utils import _setup_integration_domain, _RNG
+from .utils import _setup_integration_domain, RNG
 
 
 class MonteCarlo(BaseIntegrator):
@@ -13,7 +13,14 @@ class MonteCarlo(BaseIntegrator):
         super().__init__()
 
     def integrate(
-        self, fn, dim, N=1000, integration_domain=None, seed=None, backend="torch"
+        self,
+        fn,
+        dim,
+        N=1000,
+        integration_domain=None,
+        seed=None,
+        rng=None,
+        backend="torch",
     ):
         """Integrates the passed function on the passed domain using vanilla Monte Carlo Integration.
 
@@ -48,7 +55,10 @@ class MonteCarlo(BaseIntegrator):
             dim, integration_domain, backend
         )
         backend = infer_backend(self._integration_domain)
-        rng = _RNG(backend=backend, seed=seed)
+        if rng is None:
+            rng = RNG(backend=backend, seed=seed)
+        elif seed is not None:
+            raise ValueError("seed and rng cannot both be passed")
 
         logger.debug("Picking random sampling points")
         sample_points = []

--- a/torchquad/integration/monte_carlo.py
+++ b/torchquad/integration/monte_carlo.py
@@ -30,6 +30,7 @@ class MonteCarlo(BaseIntegrator):
             N (int, optional): Number of sample points to use for the integration. Defaults to 1000.
             integration_domain (list or backend tensor, optional): Integration domain, e.g. [[-1,1],[0,1]]. Defaults to [-1,1]^dim. It also determines the numerical backend if possible.
             seed (int, optional): Random number generation seed to the sampling point creation, only set if provided. Defaults to None.
+            rng (RNG, optional): An initialised RNG; this can be used when compiling the function for Tensorflow
             backend (string, optional): Numerical backend. This argument is ignored if the backend can be inferred from integration_domain. Defaults to "torch".
 
         Raises:
@@ -39,50 +40,70 @@ class MonteCarlo(BaseIntegrator):
             float: integral value
         """
         self._check_inputs(dim=dim, N=N, integration_domain=integration_domain)
-        logger.debug(
-            "Monte Carlo integrating a "
-            + str(dim)
-            + "-dimensional fn with "
-            + str(N)
-            + " points over "
-            + str(integration_domain),
+        logger.opt(lazy=True).debug(
+            "Monte Carlo integrating a {dim}-dimensional fn with {N} points over {dom}",
+            dim=lambda: dim,
+            N=lambda: N,
+            dom=lambda: integration_domain,
         )
+        integration_domain = _setup_integration_domain(dim, integration_domain, backend)
+        sample_points = self.calculate_sample_points(N, integration_domain, seed, rng)
+        logger.debug("Evaluating integrand")
+        function_values, self._nr_of_fevals = self.evaluate_integrand(fn, sample_points)
+        return self.calculate_result(function_values, integration_domain)
 
-        self._dim = dim
-        self._nr_of_fevals = 0
-        self.fn = fn
-        self._integration_domain = _setup_integration_domain(
-            dim, integration_domain, backend
-        )
-        backend = infer_backend(self._integration_domain)
+    def calculate_sample_points(self, N, integration_domain, seed=None, rng=None):
+        """Calculate random points for the integrand evaluation
+
+        Args:
+            N (int): Number of points
+            integration_domain (backend tensor): Integration domain
+            seed (int, optional): Random number generation seed for the sampling point creation, only set if provided. Defaults to None.
+            rng (RNG, optional): An initialised RNG; this can be used when compiling the function for Tensorflow
+
+        Returns:
+            backend tensor: Sample points
+        """
         if rng is None:
-            rng = RNG(backend=backend, seed=seed)
+            rng = RNG(backend=infer_backend(integration_domain), seed=seed)
         elif seed is not None:
             raise ValueError("seed and rng cannot both be passed")
 
         logger.debug("Picking random sampling points")
+        dim = integration_domain.shape[0]
         sample_points = []
         for d in range(dim):
-            scale = self._integration_domain[d, 1] - self._integration_domain[d, 0]
-            offset = self._integration_domain[d, 0]
+            scale = integration_domain[d, 1] - integration_domain[d, 0]
+            offset = integration_domain[d, 0]
             sample_points.append(
                 rng.uniform(size=[N], dtype=scale.dtype) * scale + offset
             )
-        # FIXME: Is there a performance difference when initializing it
-        # with zero instead of stacking it?
-        sample_points = anp.stack(sample_points, axis=1, like=self._integration_domain)
+        return anp.stack(sample_points, axis=1, like=integration_domain)
 
-        logger.debug("Evaluating integrand")
-        function_values = fn(sample_points)
+    def calculate_result(self, function_values, integration_domain):
+        """Calculate an integral result from the function evaluations
 
+        Args:
+            function_values (backend tensor): Output of the integrand
+            integration_domain (backend tensor): Integration domain
+
+        Returns:
+            backend tensor: Quadrature result
+        """
         logger.debug("Computing integration domain volume")
-        scales = self._integration_domain[:, 1] - self._integration_domain[:, 0]
+        scales = integration_domain[:, 1] - integration_domain[:, 0]
         volume = anp.prod(scales)
 
         # Integral = V / N * sum(func values)
+        N = function_values.shape[0]
         integral = volume * anp.sum(function_values) / N
         # Numpy automatically casts to float64 when dividing by N
-        if backend == "numpy" and function_values.dtype != integral.dtype:
+        if (
+            infer_backend(integration_domain) == "numpy"
+            and function_values.dtype != integral.dtype
+        ):
             integral = integral.astype(function_values.dtype)
-        logger.info("Computed integral was " + str(integral))
+        logger.opt(lazy=True).info(
+            "Computed integral: {result}", result=lambda: str(integral)
+        )
         return integral

--- a/torchquad/integration/newton_cotes.py
+++ b/torchquad/integration/newton_cotes.py
@@ -1,0 +1,86 @@
+from loguru import logger
+
+from .base_integrator import BaseIntegrator
+from .integration_grid import IntegrationGrid
+from .utils import _setup_integration_domain
+
+
+class NewtonCotes(BaseIntegrator):
+    """The abstract integrator that Composite Newton Cotes integrators inherit from"""
+
+    def __init__(self):
+        super().__init__()
+
+    def integrate(self, fn, dim, N, integration_domain, backend):
+        """Integrate the passed function on the passed domain using a Composite Newton Cotes rule.
+        The argument meanings are explained in the sub-classes.
+
+        Returns:
+            float: integral value
+        """
+        # If N is None, use the minimal required number of points per dimension
+        if N is None:
+            N = self._get_minimal_N(dim)
+
+        integration_domain = _setup_integration_domain(dim, integration_domain, backend)
+        self._check_inputs(dim=dim, N=N, integration_domain=integration_domain)
+
+        grid_points, hs, n_per_dim = self.calculate_grid(N, integration_domain)
+
+        logger.debug("Evaluating integrand on the grid.")
+        function_values, num_points = self.evaluate_integrand(fn, grid_points)
+        self._nr_of_fevals = num_points
+
+        return self.calculate_result(function_values, dim, n_per_dim, hs)
+
+    def calculate_grid(self, N, integration_domain):
+        """Calculate grid points, widths and N per dim
+
+        Args:
+            N (int): Number of points
+            integration_domain (backend tensor): Integration domain
+
+        Returns:
+            backend tensor: Grid points
+            backend tensor: Grid widths
+            int: Number of grid slices per dimension
+        """
+        N = self._adjust_N(dim=integration_domain.shape[0], N=N)
+
+        # Log with lazy to avoid redundant synchronisations with certain
+        # backends
+        logger.opt(lazy=True).debug(
+            "Creating a grid for {name} to integrate a function with {N} points over {d}.",
+            name=lambda: type(self).__name__,
+            N=lambda: str(N),
+            d=lambda: str(integration_domain),
+        )
+
+        # Create grid and assemble evaluation points
+        grid = IntegrationGrid(N, integration_domain)
+
+        return grid.points, grid.h, grid._N
+
+    def calculate_result(self, function_values, dim, n_per_dim, hs):
+        """Apply the Composite Newton Cotes rule to calculate a result from the evaluated integrand.
+
+        Args:
+            function_values (backend tensor): Output of the integrand
+            dim (int): Dimensionality
+            n_per_dim (int): Number of grid slices per dimension
+            hs (backend tensor): Distances between grid slices for each dimension
+
+        Returns:
+            backend tensor: Quadrature result
+        """
+        # Reshape the output to be [N,N,...] points instead of [dim*N] points
+        function_values = function_values.reshape([n_per_dim] * dim)
+
+        logger.debug("Computing areas.")
+
+        result = self._apply_composite_rule(function_values, dim, hs)
+
+        logger.opt(lazy=True).info(
+            "Computed integral: {result}", result=lambda: str(result)
+        )
+        return result

--- a/torchquad/integration/simpson.py
+++ b/torchquad/integration/simpson.py
@@ -2,12 +2,10 @@ from autoray import numpy as anp
 from loguru import logger
 import warnings
 
-from .base_integrator import BaseIntegrator
-from .integration_grid import IntegrationGrid
-from .utils import _setup_integration_domain
+from .newton_cotes import NewtonCotes
 
 
-class Simpson(BaseIntegrator):
+class Simpson(NewtonCotes):
 
     """Simpson's rule. See https://en.wikipedia.org/wiki/Newton%E2%80%93Cotes_formulas#Closed_Newton%E2%80%93Cotes_formulas ."""
 
@@ -27,46 +25,18 @@ class Simpson(BaseIntegrator):
         Returns:
             float: integral value
         """
+        return super().integrate(fn, dim, N, integration_domain, backend)
 
-        # If N is unspecified, set N to 3 points per dimension
-        if N is None:
-            N = 3 ** dim
+    @staticmethod
+    def _apply_composite_rule(cur_dim_areas, dim, hs):
+        """Apply composite Simpson quadrature.
 
-        self._integration_domain = _setup_integration_domain(
-            dim, integration_domain, backend
-        )
-        self._check_inputs(dim=dim, N=N, integration_domain=self._integration_domain)
-        N = self._adjust_N(dim=dim, N=N)
-
-        self._dim = dim
-        self._fn = fn
-
-        logger.debug(
-            "Using Simpson for integrating a fn with a total of "
-            + str(N)
-            + " points over "
-            + str(self._integration_domain)
-            + "."
-        )
-
-        # Create grid and assemble evaluation points
-        self._grid = IntegrationGrid(N, self._integration_domain)
-
-        logger.debug("Evaluating integrand on the grid.")
-        function_values = self._eval(self._grid.points)
-
-        # Reshape the output to be [N,N,...] points instead of [dim*N] points
-        function_values = function_values.reshape([self._grid._N] * dim)
-
-        logger.debug("Computing areas.")
-
-        # This will contain the Simpson's areas per dimension
-        cur_dim_areas = function_values
-
+        cur_dim_areas will contain the areas per dimension
+        """
         # We collapse dimension by dimension
         for cur_dim in range(dim):
             cur_dim_areas = (
-                self._grid.h[cur_dim]
+                hs[cur_dim]
                 / 3.0
                 * (
                     cur_dim_areas[..., 0:-2][..., ::2]
@@ -75,11 +45,15 @@ class Simpson(BaseIntegrator):
                 )
             )
             cur_dim_areas = anp.sum(cur_dim_areas, axis=dim - cur_dim - 1)
-        logger.info("Computed integral was " + str(cur_dim_areas) + ".")
-
         return cur_dim_areas
 
-    def _adjust_N(self, dim, N):
+    @staticmethod
+    def _get_minimal_N(dim):
+        """Get the minimal number of points N for the integrator rule"""
+        return 3 ** dim
+
+    @staticmethod
+    def _adjust_N(dim, N):
         """Adjusts the current N to an odd integer >=3, if N is not that already.
 
         Args:

--- a/torchquad/integration/trapezoid.py
+++ b/torchquad/integration/trapezoid.py
@@ -1,12 +1,9 @@
 from autoray import numpy as anp
-from loguru import logger
 
-from .base_integrator import BaseIntegrator
-from .integration_grid import IntegrationGrid
-from .utils import _setup_integration_domain
+from .newton_cotes import NewtonCotes
 
 
-class Trapezoid(BaseIntegrator):
+class Trapezoid(NewtonCotes):
     """Trapezoidal rule. See https://en.wikipedia.org/wiki/Newton%E2%80%93Cotes_formulas#Closed_Newton%E2%80%93Cotes_formulas ."""
 
     def __init__(self):
@@ -25,46 +22,23 @@ class Trapezoid(BaseIntegrator):
         Returns:
             float: integral value
         """
-        self._integration_domain = _setup_integration_domain(
-            dim, integration_domain, backend
-        )
-        self._check_inputs(dim=dim, N=N, integration_domain=self._integration_domain)
+        return super().integrate(fn, dim, N, integration_domain, backend)
 
-        logger.debug(
-            "Using Trapezoid for integrating a fn with "
-            + str(N)
-            + " points over "
-            + str(self._integration_domain)
-            + "."
-        )
+    @staticmethod
+    def _apply_composite_rule(cur_dim_areas, dim, hs):
+        """Apply composite Trapezoid quadrature.
 
-        self._dim = dim
-        self._fn = fn
-
-        # Create grid and assemble evaluation points
-        self._grid = IntegrationGrid(N, self._integration_domain)
-
-        logger.debug("Evaluating integrand on the grid.")
-        function_values = self._eval(self._grid.points)
-
-        # Reshape the output to be [N,N,...] points
-        # instead of [dim*N] points
-        function_values = function_values.reshape([self._grid._N] * dim)
-
-        logger.debug("Computing trapezoid areas.")
-
-        # This will contain the trapezoid areas per dimension
-        cur_dim_areas = function_values
-
+        cur_dim_areas will contain the areas per dimension
+        """
         # We collapse dimension by dimension
         for cur_dim in range(dim):
             cur_dim_areas = (
-                self._grid.h[cur_dim]
-                / 2.0
-                * (cur_dim_areas[..., 0:-1] + cur_dim_areas[..., 1:])
+                hs[cur_dim] / 2.0 * (cur_dim_areas[..., 0:-1] + cur_dim_areas[..., 1:])
             )
             cur_dim_areas = anp.sum(cur_dim_areas, axis=dim - cur_dim - 1)
-
-        logger.info("Computed integral was " + str(cur_dim_areas) + ".")
-
         return cur_dim_areas
+
+    @staticmethod
+    def _adjust_N(dim, N):
+        # Nothing to do for Trapezoid
+        return N

--- a/torchquad/integration/utils.py
+++ b/torchquad/integration/utils.py
@@ -139,7 +139,7 @@ def _check_integration_domain(integration_domain):
         return dim
 
 
-class _RNG:
+class RNG:
     """
     A random number generator helper class for multiple numerical backends
 

--- a/torchquad/tests/utils_integration_test.py
+++ b/torchquad/tests/utils_integration_test.py
@@ -8,7 +8,7 @@ import importlib
 import pytest
 import warnings
 
-from integration.utils import _linspace_with_grads, _setup_integration_domain, _RNG
+from integration.utils import _linspace_with_grads, _setup_integration_domain, RNG
 from utils.set_precision import set_precision
 from utils.enable_cuda import enable_cuda
 
@@ -138,11 +138,11 @@ def _run_RNG_tests(dtype_name, backend):
     backend_dtype = to_backend_dtype(dtype_name, like=backend)
     size = [3, 9]
     generateds = [
-        _RNG(backend, 547).uniform(size=size, dtype=backend_dtype),
-        _RNG(backend, None).uniform(size=size, dtype=backend_dtype),
-        _RNG(backend, 547).uniform(size=size, dtype=backend_dtype),
-        _RNG(backend).uniform(size=size, dtype=backend_dtype),
-        _RNG(backend, 42).uniform(size=size, dtype=backend_dtype),
+        RNG(backend, 547).uniform(size=size, dtype=backend_dtype),
+        RNG(backend, None).uniform(size=size, dtype=backend_dtype),
+        RNG(backend, 547).uniform(size=size, dtype=backend_dtype),
+        RNG(backend).uniform(size=size, dtype=backend_dtype),
+        RNG(backend, 42).uniform(size=size, dtype=backend_dtype),
     ]
     numpy_arrs = list(map(to_numpy, generateds))
 


### PR DESCRIPTION
To reduce code duplication I added a NewtonCotes class.
After the changes it is possible to compile only the first two steps, which could be helpful in situations where the integrand cannot be compiled.

Here are plots when benchmarking with CPU:

Everything uncompiled:
![plot_MonteCarlo_uncompiled](https://user-images.githubusercontent.com/23431138/144710651-64c41530-8448-4ba1-8862-07e6d59a9d20.png)

Tensorflow and JAX first step, third step and integrand separately compiled: 
![plot_MonteCarlo_tf_jax_parts_compiled](https://user-images.githubusercontent.com/23431138/144710643-2d52a13b-3772-44d7-8dc0-025fb4c93eea.png)

Tensorflow and JAX full integrate method compiled:
![plot_MonteCarlo_compiled_except_torch](https://user-images.githubusercontent.com/23431138/144710642-6a235003-e496-4c3c-9be9-7b076a965745.png)

Torch and Numpy are uncompiled in all plots. I have not yet tested how much the times would change if only the first and third step and not the integrand are compiled with JAX and Tensorflow.

