### PR TITLE
Add other numerical backends to the remaining tests

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -50,4 +50,5 @@ jobs:
       run: |
         cd torchquad/tests
         conda install pytest
-        $CONDA/bin/pytest -ra
+        $CONDA/bin/pip3 install pytest-error-for-skips
+        $CONDA/bin/pytest -ra --error-for-skips

--- a/torchquad/tests/gradient_test.py
+++ b/torchquad/tests/gradient_test.py
@@ -2,7 +2,9 @@ import sys
 
 sys.path.append("../")
 
-import torch
+from autoray import numpy as anp
+from autoray import to_numpy, to_backend_dtype, get_dtype_name
+import numpy as np
 
 from integration.vegas import VEGAS
 from integration.monte_carlo import MonteCarlo
@@ -10,60 +12,176 @@ from integration.trapezoid import Trapezoid
 from integration.simpson import Simpson
 from integration.boole import Boole
 
-from utils.enable_cuda import enable_cuda
-from utils.set_precision import set_precision
-from utils.set_log_level import set_log_level
+from integration_test_utils import setup_test_for_backend
 
 
-def some_function(x):
-    """V shaped test function.
+def _v_function(x):
+    """
+    V shaped test function 2 |x|.
     Gradient in positive x should be 2,
     Gradient in negative x should be -2
-    for -1 to 1 domain."""
-    return 2 * torch.abs(x)
+    for -1 to 1 domain.
+    """
+    return 2 * anp.abs(x)
 
 
-def test_gradients():
-    """Tests that the implemented integrators
-    maintain torch gradients and they are consistent and correct"""
-    set_log_level("INFO")
-    enable_cuda()
-    set_precision("double")
+def _polynomial_function(x):
+    """
+    2D test function 3 x_1 ^ 2 + 2 x_0 + 1.
+    The four gradient components are integrals of the function over the
+    integration domain rectangle's four sides multiplied by the factors
+    -1, -1, 1 and 1 for the sides -X_1, -X_2, X_1 and X_2 respectively.
+    For example, with integration_domain [[0.0, 1.0], [0.0, 2.0]],
+    the gradient of the integral with respect to this domain is
+    [[-10.0, 14.0], [-2.0, 14.0]].
+    """
+    return 1.0 + 2.0 * x[:, 0] + 3.0 * x[:, 1] ** 2
 
-    N = 99997
-    result_tolerence = 1e-2
-    gradient_tolerance = 2e-2
 
-    # Define integrators
-    integrators = [MonteCarlo(), Trapezoid(), Simpson(), Boole(), VEGAS()]
-    for integrator in integrators:
-        print("Running integrator...", integrator)
+def _calculate_gradient(
+    backend, integration_domain, integrate, integrate_kwargs, dtype_name
+):
+    """
+    Backend-specific gradient calculation
+
+    Args:
+        backend (string): Numerical backend, e.g. "torch"
+        integration_domain (list): Integration domain
+        integrate (function): A integrator's integrate method
+        integrate_kwargs (dict): Arguments for integrate except integration_domain
+        dtype_name (string): Floating point precision
+
+    Returns:
+        backend tensor: Gradient with respect to integration_domain
+        backend tensor or None: Integral result if available
+    """
+    if backend == "torch":
+        import torch
+
+        # Set up integration_domain for gradient calculation
+        integration_domain = torch.tensor(integration_domain)
+        integration_domain.requires_grad = True
 
         # Compute integral
-        domain = torch.tensor([[-1.0, 1.0]])
-        domain.requires_grad = True
+        result = integrate(integration_domain=integration_domain, **integrate_kwargs)
+        result_np = to_numpy(result)
 
-        extra_args = {}
-        if type(integrator).__name__ == "MonteCarlo":
-            extra_args["seed"] = 0
-        result = integrator.integrate(
-            some_function, dim=1, N=N, integration_domain=domain, **extra_args
+        # Check for presence of gradient and correct dtype
+        assert hasattr(result, "grad_fn")
+        assert get_dtype_name(result) == dtype_name
+
+        # Backprop gradient through integral and get the gradient
+        result.backward()
+        gradient = integration_domain.grad
+        assert get_dtype_name(gradient) == dtype_name
+
+        return to_numpy(gradient), result_np
+
+    elif backend == "jax":
+        import jax
+
+        integration_domain = anp.array(integration_domain, like="jax")
+
+        # Create a derivation of integrate with respect to integration_domain
+        @jax.grad
+        def grad_integrate(dom):
+            return integrate(integration_domain=dom, **integrate_kwargs)
+
+        # Calculate the gradient
+        gradient = grad_integrate(integration_domain)
+        assert get_dtype_name(gradient) == dtype_name
+        return to_numpy(gradient), None
+
+    elif backend == "tensorflow":
+        import tensorflow as tf
+
+        # Set up integration_domain as Variable
+        dtype = to_backend_dtype(dtype_name, like=backend)
+        integration_domain = tf.Variable(integration_domain, dtype=dtype)
+
+        # Calculate the integral and gradient
+        with tf.GradientTape() as tape:
+            result = integrate(
+                integration_domain=integration_domain, **integrate_kwargs
+            )
+        assert get_dtype_name(result) == dtype_name
+        gradient = tape.gradient(result, integration_domain)
+        assert get_dtype_name(gradient) == dtype_name
+        return to_numpy(gradient), to_numpy(result)
+
+    else:
+        raise ValueError(f"No gradient calculation for the backend {backend}")
+
+
+def _run_gradient_tests(backend, precision):
+    """
+    Test if the implemented integrators
+    maintain gradients and if the gradients are consistent and correct
+    """
+    dtype_name = {"float": "float32", "double": "float64"}[precision]
+    # Define integrators and numbers of evaluation points
+    integrators = [Trapezoid(), Simpson(), Boole(), MonteCarlo(), VEGAS()]
+    Ns_1d = [149, 149, 149, 99997, 99997]
+    Ns_2d = [549, 121, 81, 99997, 99997]
+    for integrator, N_1d, N_2d in zip(integrators, Ns_1d, Ns_2d):
+        integrator_name = type(integrator).__name__
+        if backend != "torch" and integrator_name == "VEGAS":
+            # Currently VEGAS supports only Torch.
+            continue
+
+        print(
+            f"Calculating gradients with backend {backend} and integrator {integrator}"
         )
 
-        # Check results are correct
-        assert torch.abs(result - 2.0) < result_tolerence
+        # Test gradient calculation with the one-dimensional V-shaped function
+        integrate_kwargs = {"fn": _v_function, "dim": 1, "N": N_1d}
+        if integrator_name == "MonteCarlo":
+            integrate_kwargs["seed"] = 0
+        gradient, integral = _calculate_gradient(
+            backend,
+            [[-1.0, 1.0]],
+            integrator.integrate,
+            integrate_kwargs,
+            dtype_name,
+        )
+        if integral is not None:
+            # Check if the integral is accurate enough
+            true_integral = 2.0
+            assert np.abs(integral - true_integral) < 1e-2
+        # Check if the gradient is accurate enough
+        true_gradient = np.array([-2.0, 2.0])
+        assert gradient.shape == (1, 2)
+        assert np.all(np.abs(gradient - true_gradient) < 2e-2)
 
-        # Check for presence of gradient
-        assert hasattr(result, "grad_fn")
+        # Test gradient calculation with a two-dimensional polynomial
+        integrate_kwargs = {"fn": _polynomial_function, "dim": 2, "N": N_2d}
+        if integrator_name == "MonteCarlo":
+            integrate_kwargs["seed"] = 0
+        gradient, integral = _calculate_gradient(
+            backend,
+            [[0.0, 1.0], [0.0, 2.0]],
+            integrator.integrate,
+            integrate_kwargs,
+            dtype_name,
+        )
+        if integral is not None:
+            # Check if the integral is accurate enough
+            true_integral = 12.0
+            assert np.abs(integral - true_integral) < 4e-2
+        # Check if the gradient is accurate enough
+        true_gradient = np.array([[-10.0, 14.0], [-2.0, 14.0]])
+        assert gradient.shape == (2, 2)
+        assert np.all(np.abs(gradient - true_gradient) < 5e-2)
 
-        # Backprop gradient through integral
-        result.backward()
 
-        # Check that gradient is correct
-        assert torch.abs(domain.grad[0, 0] + 2.0) < gradient_tolerance
-        assert torch.abs(domain.grad[0, 1] - 2.0) < gradient_tolerance
-
+test_gradients_torch = setup_test_for_backend(_run_gradient_tests, "torch", "double")
+test_gradients_jax = setup_test_for_backend(_run_gradient_tests, "jax", "double")
+test_gradients_tensorflow = setup_test_for_backend(
+    _run_gradient_tests, "tensorflow", "double"
+)
 
 if __name__ == "__main__":
     # used to run this test individually
-    test_gradients()
+    test_gradients_torch()
+    test_gradients_jax()
+    test_gradients_tensorflow()

--- a/torchquad/tests/integration_grid_test.py
+++ b/torchquad/tests/integration_grid_test.py
@@ -2,70 +2,86 @@ import sys
 
 sys.path.append("../")
 
-import torch
+from autoray import numpy as anp
+from autoray import to_backend_dtype
 
 from integration.integration_grid import IntegrationGrid
-from utils.set_log_level import set_log_level
-
-torch.set_printoptions(10)
+from integration_test_utils import setup_test_for_backend
 
 
-def test_integration_grid():
-    """Tests the integration grid in integration.integration_grid for illegal values."""
-    set_log_level("INFO")
+def _check_grid_validity(grid, integration_domain, N, eps):
+    """Check if a specific grid object contains illegal values"""
+    assert grid._N == int(
+        N ** (1 / len(integration_domain)) + 1e-8
+    ), "Incorrect number of points per dimension"
+    assert grid.points.shape == (
+        int(N),
+        integration_domain.shape[0],
+    ), "Incorrect number of calculated points"
+    assert (
+        grid.points.dtype == integration_domain.dtype
+    ), "Grid points have an incorrect dtype"
+    assert (
+        grid.h.dtype == integration_domain.dtype
+    ), "Mesh widths have an incorrect dtype"
+    for dim in range(len(integration_domain)):
+        domain_width = integration_domain[dim][1] - integration_domain[dim][0]
+        assert (
+            anp.abs(grid.h[dim] - domain_width / (grid._N - 1)) < eps
+        ), "Incorrect mesh width"
+        assert (
+            anp.min(grid.points[:, dim]) >= integration_domain[dim][0]
+        ), "Points are outside of the integration domain"
+        assert (
+            anp.max(grid.points[:, dim]) <= integration_domain[dim][1]
+        ), "Points are outside of the integration domain"
+
+
+def _run_integration_grid_tests(backend, precision):
+    """
+    Test IntegrationGrid in integration.integration_grid for illegal values with various input arguments
+    """
+    if backend == "torch":
+        import torch
+
+        torch.set_printoptions(10)
+
     # Generate a grid in different dimensions with different N on different domains
     eps = 2e-8  # error bound
+    dtype_name = {"float": "float32", "double": "float64"}[precision]
+    dtype = to_backend_dtype(dtype_name, like=backend)
 
     # Test 1: N is float, 1-D
-    N = 10.0
-    integration_domain = [[0, 1]]
-    grid = IntegrationGrid(N, integration_domain)
-
-    # Test if number of points is correct
-    assert grid._N == N
-    assert len(grid.points) == N
-    for dim in range(len(integration_domain)):
-        # Test if mesh width is correct
-        assert torch.abs(grid.h[dim] - 1 / (N - 1)) < eps
-        # Test if all points are inside
-        assert torch.all(grid.points[:, dim] >= integration_domain[dim][0])
-        assert torch.all(grid.points[:, dim] <= integration_domain[dim][1])
-    # print("1-D (float) test: N =", N, ", grid_N =", grid._N, ", error:", torch.abs(grid.h[dim] - 1 / (N - 1)))
-
     # Test 2: N is int, 3-D
-    N = 4 ** 3
-    integration_domain = [[0, 2], [-2, 1], [0.5, 1]]
-    grid = IntegrationGrid(N, integration_domain)
-
-    # Test if number of points is correct
-    assert grid._N == int(N ** (1 / len(integration_domain)) + 1e-8)
-    assert len(grid.points) == N
-    for dim in range(len(integration_domain)):
-        domain_width = integration_domain[dim][1] - integration_domain[dim][0]
-        # Test if mesh width is correct
-        assert torch.abs(grid.h[dim] - domain_width / (grid._N - 1)) < eps
-        # Test if all points are inside
-        assert torch.all(grid.points[:, dim] >= integration_domain[dim][0])
-        assert torch.all(grid.points[:, dim] <= integration_domain[dim][1])
-    # print("3-D (int) test: N =", N, ", grid_N = N^(1/3) =", grid._N, ", error:", torch.abs(grid.h[dim] - domain_width / (grid._N - 1)))
-
     # Test 3: N is float, 3-D
-    N = 4.0 ** 3
-    integration_domain = [[0, 2], [-2, 1], [0.5, 1]]
-    grid = IntegrationGrid(N, integration_domain)
+    Ns = [10.0, 4 ** 3, 4.0 ** 3]
+    domains = [
+        [[0.0, 1.0]],
+        [[0.0, 2.0], [-2.0, 1.0], [0.5, 1.0]],
+        [[0.0, 2.0], [-2.0, 1.0], [0.5, 1.0]],
+    ]
+    for N, dom in zip(Ns, domains):
+        integration_domain = anp.array(dom, dtype=dtype, like=backend)
+        grid = IntegrationGrid(N, integration_domain)
+        _check_grid_validity(grid, integration_domain, N, eps)
 
-    # Test if number of points is correct
-    assert grid._N == int(N ** (1 / len(integration_domain)) + 1e-8)
-    assert len(grid.points) == N
-    for dim in range(len(integration_domain)):
-        domain_width = integration_domain[dim][1] - integration_domain[dim][0]
-        # Test if mesh width is correct
-        assert torch.abs(grid.h[dim] - domain_width / (grid._N - 1)) < eps
-        # Test if all points are inside
-        assert torch.all(grid.points[:, dim] >= integration_domain[dim][0])
-        assert torch.all(grid.points[:, dim] <= integration_domain[dim][1])
-    # print("3-D (float) test: N =", N, ", grid_N = N^(1/3) =", grid._N, ", error:", torch.abs(grid.h[dim] - domain_width / (grid._N - 1)))
+
+test_integration_grid_numpy = setup_test_for_backend(
+    _run_integration_grid_tests, "numpy", "double"
+)
+test_integration_grid_torch = setup_test_for_backend(
+    _run_integration_grid_tests, "torch", "double"
+)
+test_integration_grid_jax = setup_test_for_backend(
+    _run_integration_grid_tests, "jax", "double"
+)
+test_integration_grid_tensorflow = setup_test_for_backend(
+    _run_integration_grid_tests, "tensorflow", "double"
+)
 
 
 if __name__ == "__main__":
-    test_integration_grid()
+    test_integration_grid_numpy()
+    test_integration_grid_torch()
+    test_integration_grid_jax()
+    test_integration_grid_tensorflow()


### PR DESCRIPTION
I changed the gradient and IntegrationGrid tests, and modified the github action so that it fails if a pytest skip happens, i.e. if a numerical backend cannot be imported.