### PR TITLE
Add a method to NewtonCotes and MonteCarlo for JIT compilation

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -12,22 +12,22 @@ Minimal working example
 
 .. code:: ipython3
 
-    # To avoid copying things to GPU memory, 
+    # To avoid copying things to GPU memory,
     # ideally allocate everything in torch on the GPU
     # and avoid non-torch function calls
-    import torch 
+    import torch
     from torchquad import MonteCarlo
 
     # The function we want to integrate, in this example f(x0,x1) = sin(x0) + e^x1 for x0=[0,1] and x1=[-1,1]
     # Note that the function needs to support multiple evaluations at once (first dimension of x here)
     # Expected result here is ~3.2698
     def some_function(x):
-        return torch.sin(x[:,0]) + torch.exp(x[:,1]) 
+        return torch.sin(x[:,0]) + torch.exp(x[:,1])
 
     # Declare an integrator, here we use the simple, stochastic Monte Carlo integration method
     mc = MonteCarlo()
 
-    # Compute the function integral by sampling 10000 points over domain 
+    # Compute the function integral by sampling 10000 points over domain
     integral_value = mc.integrate(some_function,dim=2,N=10000,integration_domain = [[0,1],[-1,1]])
 
 To set the default logger verbosity, change the ``TORCHQUAD_LOG_LEVEL``
@@ -94,20 +94,20 @@ Now let’s get started! First, the general imports:
 
     import scipy
     import numpy as np
-    
+
     # For benchmarking
     import time
     from scipy.integrate import nquad
-    
+
     # For plotting
     import matplotlib.pyplot as plt
-    
-    # To avoid copying things to GPU memory, 
+
+    # To avoid copying things to GPU memory,
     # ideally allocate everything in torch on the GPU
     # and avoid non-torch function calls
     import torch
     torch.set_printoptions(precision=10) # Set displayed output precision to 10 digits
-    
+
     from torchquad import Trapezoid, Simpson, Boole, MonteCarlo, VEGAS # The available integrators
     import torchquad  # Initialize torchquad with CUDA support if possible
 
@@ -116,33 +116,33 @@ One-dimensional integration
 ----------------------------
 
 To make it easier to understand the methods used in this notebook, we will start with an
-example in one dimension. If you are new to these methods or simply want a clearer picture, 
-feel free to check out Patrick Walls’ 
-`nice Python introduction <https://github.com/patrickwalls/mathematical-python/>`__ 
+example in one dimension. If you are new to these methods or simply want a clearer picture,
+feel free to check out Patrick Walls’
+`nice Python introduction <https://github.com/patrickwalls/mathematical-python/>`__
 to the `Trapezoid rule <https://www.math.ubc.ca/~pwalls/math-python/integration/trapezoid-rule/>`__
 and `Simpson’s rule <https://www.math.ubc.ca/~pwalls/math-python/integration/simpsons-rule/>`__
 in one dimension.
-Similarly, `Tirthajyoti Sarkar <https://github.com/tirthajyoti>`__ has made a nice visual explanation of 
-`Monte Carlo integration in Python 
+Similarly, `Tirthajyoti Sarkar <https://github.com/tirthajyoti>`__ has made a nice visual explanation of
+`Monte Carlo integration in Python
 <https://towardsdatascience.com/monte-carlo-integration-in-python-a71a209d277e>`__.
 
-Let ``f(x)`` be the function :math:`f(x) = e^{x} \cdot x^{2}`. Over the domain 
-:math:`[0,2]`, the integral of ``f(x)`` is :math:`\int_{0}^{2} f(x) dx = 
+Let ``f(x)`` be the function :math:`f(x) = e^{x} \cdot x^{2}`. Over the domain
+:math:`[0,2]`, the integral of ``f(x)`` is :math:`\int_{0}^{2} f(x) dx =
 \int_{0}^{2} e^x \cdot x^2 dx = 2(e^{2} - 1) = 12.7781121978613004544...`
 
-Let’s declare the function and a simple function to print the absolute error, 
+Let’s declare the function and a simple function to print the absolute error,
 as well as remember the correct result.
 
 .. code:: ipython3
 
     def f(x):
         return torch.exp(x) * torch.pow(x,2)
-    
+
     def print_error(result,solution):
         print("Results:",result.item())
         print(f"Abs. Error: {(torch.abs(result - solution).item()):.8e}")
         print(f"Rel. Error: {(torch.abs((result - solution) / solution).item()):.8e}")
-    
+
     solution = 2*(torch.exp(torch.tensor([2.]))-1)
 
 **Note that we are using the torch versions to ensure that all variables
@@ -182,7 +182,7 @@ Now we are all set to compute the integral. Let’s try it with just 101 sample 
     **Output**: Results: 12.780082702636719
             Abs. Error: 1.97029114e-03
             Rel. Error: 1.54192661e-04
-    
+
 
 This is quite close already, as 1-D integrals are comparatively easy.
 Let’s see what type of value we get for different integrators.
@@ -199,7 +199,7 @@ Let’s see what type of value we get for different integrators.
     **Output:** Results: 12.778112411499023
             Abs. Error: 0.00000000e+00
             Rel. Error: 0.00000000e+00
-    
+
 
 .. code:: ipython3
 
@@ -213,7 +213,7 @@ Let’s see what type of value we get for different integrators.
     **Output:** Results: 13.32831859588623
             Abs. Error: 5.50206184e-01
             Rel. Error: 4.30584885e-02
-    
+
 
 .. code:: ipython3
 
@@ -227,12 +227,12 @@ Let’s see what type of value we get for different integrators.
     **Output:** Results: 21.83991813659668
             Abs. Error: 9.06180573e+00
             Rel. Error: 7.09166229e-01
-    
 
-Notably, Simpson’s method is already sufficient for a perfect solution here with 101 points. 
-Monte Carlo methods do not perform so well; they are more suited to higher-dimensional integrals. 
+
+Notably, Simpson’s method is already sufficient for a perfect solution here with 101 points.
+Monte Carlo methods do not perform so well; they are more suited to higher-dimensional integrals.
 VEGAS currently requires a larger number of samples to function correctly (as it performs several
-iterations). 
+iterations).
 
 Let’s step things up now and move to a 10-dimensional problem.
 
@@ -252,18 +252,18 @@ Plotting this is tricky, so let’s directly move to the integrals.
 
     def f_2(x):
         return torch.sum(torch.sin(x),dim=1)
-    
+
     solution = 20*(torch.sin(torch.tensor([0.5]))*torch.sin(torch.tensor([0.5])))
 
-Let’s start with just 3 points per dimension, i.e., :math:`3^{10}=59,049` sample points. 
+Let’s start with just 3 points per dimension, i.e., :math:`3^{10}=59,049` sample points.
 
-**Note**: *torchquad* currently only supports equal numbers of points per dimension. 
+**Note**: *torchquad* currently only supports equal numbers of points per dimension.
 We are working on giving the user more flexibility on this point.
 
 .. code:: ipython3
 
     integration_domain = [[0, 1]]*10 # Integration domain always is a list of lists to allow arbitrary dimensionality
-    N = 3**10 
+    N = 3**10
 
 .. code:: ipython3
 
@@ -277,7 +277,7 @@ We are working on giving the user more flexibility on this point.
     **Output:** Results: 4.500804901123047
             Abs. Error: 9.61723328e-02
             Rel. Error: 2.09207758e-02
-    
+
 
 .. code:: ipython3
 
@@ -291,7 +291,7 @@ We are working on giving the user more flexibility on this point.
     **Output:** Results: 4.598623752593994
             Abs. Error: 1.64651871e-03
             Rel. Error: 3.58174206e-04
-    
+
 
 .. code:: ipython3
 
@@ -305,7 +305,7 @@ We are working on giving the user more flexibility on this point.
     **Output:** Results: 4.598303318023682
             Abs. Error: 1.32608414e-03
             Rel. Error: 2.88468727e-04
-    
+
 
 .. code:: ipython3
 
@@ -319,16 +319,16 @@ We are working on giving the user more flexibility on this point.
     **Output:** Results: 4.598696708679199
             Abs. Error: 1.71947479e-03
             Rel. Error: 3.74044670e-04
-    
+
 
 Note that the Monte Carlo methods are much more competitive for
 this case. The bad convergence properties of the trapezoid method are
 visible while Simpson’s rule is still OK given the comparatively smooth
 integrand.
 
-If you have been repeating the examples from this tutorial on your own computer, you could also try 
+If you have been repeating the examples from this tutorial on your own computer, you could also try
 increasing N to :math:`5^{10}=9,765,625`.
-You can see the curse of dimensionality fully at play here, and 
+You can see the curse of dimensionality fully at play here, and
 some users might even experience running out of memory at this point.
 
 Comparison with scipy
@@ -346,10 +346,10 @@ remain on the CPU and torch tensor on the GPU.
     dimension = 5
     integration_domain = [[0, 1]]*dimension
     ground_truth = 2 * dimension * np.sin(0.5)*np.sin(0.5)
-    
+
     def f_3(x):
         return torch.sum(torch.sin(x),dim=1)
-    
+
     def f_3_np(*x):
         return np.sum(np.sin(x))
 
@@ -359,7 +359,7 @@ Now let’s evaluate the integral using the scipy function ``nquad``.
 
     start = time.time()
     opts={"limit": 10, "epsabs" : 1, "epsrel" : 1}
-    result, _,details = nquad(f_3_np, integration_domain, opts=opts, full_output=True) 
+    result, _,details = nquad(f_3_np, integration_domain, opts=opts, full_output=True)
     end = time.time()
     print("Results:",result)
     print("Abs. Error:",np.abs(result - ground_truth))
@@ -373,7 +373,7 @@ Now let’s evaluate the integral using the scipy function ``nquad``.
             Abs. Error: 0.0
             {'neval': 4084101}
             Took 33067.629 ms
-    
+
 
 Using scipy, we get the result in about 33 seconds on the authors’
 machine (this might take shorter or longer on your machine). The integral was computed with
@@ -381,11 +381,11 @@ machine (this might take shorter or longer on your machine). The integral was co
 `QUADPACK <https://en.wikipedia.org/wiki/QUADPACK>`__ algorithm.
 
 In any event, *torchquad* can reach the same accuracy much, much quicker
-by utilizing the GPU. 
+by utilizing the GPU.
 
 .. code:: ipython3
 
-    N = 37**dimension 
+    N = 37**dimension
     simp = Simpson()  # Initialize Simpson solver
     start = time.time()
     result = simp.integrate(f_3, dim=dimension, N=N, integration_domain=integration_domain)
@@ -395,16 +395,16 @@ by utilizing the GPU.
     print(f"Took {(end-start)* 1000.0:.3f} ms")
 
 
-If you tried this yourself and ran out of CUDA memory, simply decrease :math:`N` 
-(this will, however, lead to a loss of accuracy). 
+If you tried this yourself and ran out of CUDA memory, simply decrease :math:`N`
+(this will, however, lead to a loss of accuracy).
 
-Note that we use more evaluation points (:math:`37^{5}=69,343,957` for *torchquad* vs. :math:`4,084,101` 
-for scipy), given the comparatively simple algorithm. 
+Note that we use more evaluation points (:math:`37^{5}=69,343,957` for *torchquad* vs. :math:`4,084,101`
+for scipy), given the comparatively simple algorithm.
 Anyway, the decisive factor for this specific problem is runtime. A comparison with regard to
 function evaluations is difficult, as ``nquad`` provides no support for a
 fixed number of evaluations. This may follow in the future.
 
-The results from using Simpson’s rule in *torchquad* is: 
+The results from using Simpson’s rule in *torchquad* is:
 
 .. parsed-literal::
 
@@ -413,7 +413,7 @@ The results from using Simpson’s rule in *torchquad* is:
             Rel. Error: 0.00000000e+00
             neval= 69343957
             Took 162.147 ms
-    
+
 
 In our case, *torchquad*  with Simpson’s rule was more than 300 times faster than
 ``scipy.integrate.nquad``. We will add
@@ -460,10 +460,85 @@ We selected the Trapezoid rule and the Monte Carlo method to showcase that getti
 
 The code above calculates the integral for a 1-D test-function ``test_function()`` in the [-1,1] domain and prints the gradients with respect to the integration domain.
 The command ``domain.requires_grad = True`` enables the creation of a computational graph, and it shall be called before calling the ``integrate(...)`` method.
-Gradients computation is, then, performed calling ``result.backward()``. 
+Gradients computation is, then, performed calling ``result.backward()``.
 The output of the code is as follows:
 
 .. parsed-literal::
 
     **Output:** Method: <torchquad.integration.monte_carlo.MonteCarlo object at 0x7f724735b6a0> Gradients: tensor([[-1.9872,  2.0150]])
             Method: <torchquad.integration.trapezoid.Trapezoid object at 0x7f724735b6d0> Gradients: tensor([[-2.0000,  2.0000]])
+
+
+Compiling the integrate method
+------------------------------
+
+To speed up the quadrature in situations where it is executed often with the
+same number of points ``N`` and dimensionality ``dim``,
+we can JIT-compile the performance-relevant parts of the integrate method:
+
+.. code:: ipython3
+
+    import time
+    import torch
+    from torchquad import Boole, set_precision
+
+
+    def example_integrand(x):
+        return torch.sum(torch.sin(x), dim=1)
+
+
+    set_precision("float")
+    N = 912673
+    dim = 3
+    integrator = Boole()
+    domains = [torch.tensor([[-1.0, y]] * dim) for y in range(5)]
+
+    # Integrate without compilation
+    times_uncompiled = []
+    for integration_domain in domains:
+        t0 = time.perf_counter()
+        integrator.integrate(example_integrand, dim, N, integration_domain)
+        times_uncompiled.append(time.perf_counter() - t0)
+
+    # Integrate with partial compilation
+    integrate_jit_compiled_parts = integrator.get_jit_compiled_integrate(
+        dim, N, backend="torch"
+    )
+    times_compiled_parts = []
+    for integration_domain in domains:
+        t0 = time.perf_counter()
+        integrate_jit_compiled_parts(example_integrand, integration_domain)
+        times_compiled_parts.append(time.perf_counter() - t0)
+
+    # Integrate with everything compiled
+    times_compiled_all = []
+    integrate_compiled = None
+    for integration_domain in domains:
+        t0 = time.perf_counter()
+        if integrate_compiled is None:
+            integrate_compiled = torch.jit.trace(
+                lambda dom: integrator.integrate(example_integrand, dim, N, dom),
+                (integration_domain,),
+            )
+        integrate_compiled(integration_domain)
+        times_compiled_all.append(time.perf_counter() - t0)
+
+    print(f"Uncompiled times: {times_uncompiled}")
+    print(f"Partly compiled times: {times_compiled_parts}")
+    print(f"All compiled times: {times_compiled_all}")
+    speedups = [
+        (1.0, tu / tcp, tu / tca)
+        for tu, tcp, tca in zip(times_uncompiled, times_compiled_parts, times_compiled_all)
+    ]
+    print(f"Speedup factors: {speedups}")
+
+This code shows two ways of compiling the integration.
+In the first case, we use ``integrator.get_jit_compiled_integrate``,
+which internally uses ``torch.jit.trace`` to compile performance-relevant code
+parts except the integrand evaluation.
+In the second case we directly compile ``integrator.integrate``.
+The function created in the first case may be a bit slower,
+but it works even if the integrand cannot be compiled and we can re-use it
+with other integrand functions.
+The compilations happen in the first iteration of the for loops and in the
+following iterations the previously compiled functions are re-used.

--- a/torchquad/integration/monte_carlo.py
+++ b/torchquad/integration/monte_carlo.py
@@ -52,6 +52,111 @@ class MonteCarlo(BaseIntegrator):
         function_values, self._nr_of_fevals = self.evaluate_integrand(fn, sample_points)
         return self.calculate_result(function_values, integration_domain)
 
+    def jit_integrate(
+        self, dim, N=1000, integration_domain=None, seed=None, rng=None, backend="torch"
+    ):
+        """Create an integrate function where the performance-relevant steps except the integrand evaluation are JIT compiled.
+        Use this method only if the integrand cannot be compiled.
+        The compilation happens when the function is executed the first time.
+        With PyTorch, return values of different integrands passed to the compiled function must all have the same format, e.g. precision.
+
+        Args:
+            dim (int): Dimensionality of the integration domain.
+            N (int, optional): Number of sample points to use for the integration. Defaults to 1000.
+            integration_domain (list or backend tensor, optional): Integration domain, e.g. [[-1,1],[0,1]]. Defaults to [-1,1]^dim. It also determines the numerical backend if possible.
+            seed (int, optional): Random number generation seed to the sampling point creation, only set if provided. Defaults to None.
+            rng (RNG, optional): An initialised RNG; this must be specified with Tensorflow and omitted with JAX
+            backend (string, optional): Numerical backend. This argument is ignored if the backend can be inferred from integration_domain. Defaults to "torch".
+
+        Returns:
+            function(fn, integration_domain): JIT compiled integrate function where all parameters except the integrand and domain are fixed
+        """
+        self._check_inputs(dim=dim, N=N, integration_domain=integration_domain)
+        integration_domain = _setup_integration_domain(dim, integration_domain, backend)
+        backend = infer_backend(integration_domain)
+        if backend in ["tensorflow", "jax"]:
+            # Tensorflow and JAX automatically recompile functions if
+            # the parameters change
+            if backend == "tensorflow":
+                if not hasattr(self, "_tf_jit_calculate_sample_points"):
+                    import tensorflow as tf
+
+                    self._tf_jit_calculate_sample_points = tf.function(
+                        self.calculate_sample_points, jit_compile=True
+                    )
+                    self._tf_jit_calculate_result = tf.function(
+                        self.calculate_result, jit_compile=True
+                    )
+                jit_calculate_sample_points = self._tf_jit_calculate_sample_points
+                jit_calculate_result = self._tf_jit_calculate_result
+            elif backend == "jax":
+                if not hasattr(self, "_jax_jit_calculate_sample_points"):
+                    import jax
+
+                    self._jax_jit_calculate_sample_points = jax.jit(
+                        self.calculate_sample_points, static_argnames=["N"]
+                    )
+                    self._jax_jit_calculate_result = jax.jit(
+                        self.calculate_result, static_argnames=["dim", "n_per_dim"]
+                    )
+                jit_calculate_sample_points = self._jax_jit_calculate_sample_points
+                jit_calculate_result = self._jax_jit_calculate_result
+
+            def compiled_integrate(fn, integration_domain):
+                sample_points = jit_calculate_sample_points(
+                    N, integration_domain, seed, rng
+                )
+                function_values, _ = self.evaluate_integrand(fn, sample_points)
+                return jit_calculate_result(function_values, integration_domain)
+
+            return compiled_integrate
+
+        elif backend == "torch":
+            # Torch requires explicit tracing with example inputs.
+            def do_compile(example_integrand):
+                import torch
+
+                # Define traceable first and third steps
+                def step1(integration_domain):
+                    return self.calculate_sample_points(
+                        N, integration_domain, seed, rng
+                    )
+
+                step3 = self.calculate_result
+
+                # Trace the first step (which is non-deterministic)
+                step1 = torch.jit.trace(step1, (integration_domain,), check_trace=False)
+
+                # Get example input for the third step
+                sample_points = step1(integration_domain)
+                function_values, _ = self.evaluate_integrand(
+                    example_integrand, sample_points
+                )
+
+                # Trace the third step
+                step3 = torch.jit.trace(step3, (function_values, integration_domain))
+
+                # Define a compiled integrate function
+                def compiled_integrate(fn, integration_domain):
+                    sample_points = step1(integration_domain)
+                    function_values, _ = self.evaluate_integrand(fn, sample_points)
+                    return step3(function_values, integration_domain)
+
+                return compiled_integrate
+
+            # Do the compilation when the returned function is executed the
+            # first time
+            compiled_func = [None]
+
+            def lazy_compiled_integrate(fn, integration_domain):
+                if compiled_func[0] is None:
+                    compiled_func[0] = do_compile(fn)
+                return compiled_func[0](fn, integration_domain)
+
+            return lazy_compiled_integrate
+
+        raise ValueError(f"Compilation not implemented for backend {backend}")
+
     def calculate_sample_points(self, N, integration_domain, seed=None, rng=None):
         """Calculate random points for the integrand evaluation
 

--- a/torchquad/integration/newton_cotes.py
+++ b/torchquad/integration/newton_cotes.py
@@ -34,7 +34,9 @@ class NewtonCotes(BaseIntegrator):
 
         return self.calculate_result(function_values, dim, n_per_dim, hs)
 
-    def jit_integrate(self, dim, N=None, integration_domain=None, backend="torch"):
+    def get_jit_compiled_integrate(
+        self, dim, N=None, integration_domain=None, backend="torch"
+    ):
         """Create an integrate function where the performance-relevant steps except the integrand evaluation are JIT compiled.
         Use this method only if the integrand cannot be compiled.
         The compilation happens when the function is executed the first time.

--- a/torchquad/integration/newton_cotes.py
+++ b/torchquad/integration/newton_cotes.py
@@ -1,4 +1,5 @@
 from loguru import logger
+from autoray import infer_backend
 
 from .base_integrator import BaseIntegrator
 from .integration_grid import IntegrationGrid
@@ -32,6 +33,118 @@ class NewtonCotes(BaseIntegrator):
         self._nr_of_fevals = num_points
 
         return self.calculate_result(function_values, dim, n_per_dim, hs)
+
+    def jit_integrate(self, dim, N=None, integration_domain=None, backend="torch"):
+        """Create an integrate function where the performance-relevant steps except the integrand evaluation are JIT compiled.
+        Use this method only if the integrand cannot be compiled.
+        The compilation happens when the function is executed the first time.
+        With PyTorch, return values of different integrands passed to the compiled function must all have the same format, e.g. precision.
+
+        Args:
+            dim (int): Dimensionality of the integration domain.
+            N (int, optional): Total number of sample points to use for the integration. See the integrate method documentation for more details.
+            integration_domain (list or backend tensor, optional): Integration domain, e.g. [[-1,1],[0,1]]. Defaults to [-1,1]^dim. It also determines the numerical backend if possible.
+            backend (string, optional): Numerical backend. This argument is ignored if the backend can be inferred from integration_domain. Defaults to "torch".
+
+        Returns:
+            function(fn, integration_domain): JIT compiled integrate function where all parameters except the integrand and domain are fixed
+        """
+        # If N is None, use the minimal required number of points per dimension
+        if N is None:
+            N = self._get_minimal_N(dim)
+
+        integration_domain = _setup_integration_domain(dim, integration_domain, backend)
+        self._check_inputs(dim=dim, N=N, integration_domain=integration_domain)
+        backend = infer_backend(integration_domain)
+        if backend in ["tensorflow", "jax"]:
+            # Tensorflow and JAX automatically recompile functions if
+            # the parameters change
+            if backend == "tensorflow":
+                if not hasattr(self, "_tf_jit_calculate_grid"):
+                    import tensorflow as tf
+
+                    self._tf_jit_calculate_grid = tf.function(
+                        self.calculate_grid, jit_compile=True
+                    )
+                    self._tf_jit_calculate_result = tf.function(
+                        self.calculate_result, jit_compile=True
+                    )
+                jit_calculate_grid = self._tf_jit_calculate_grid
+                jit_calculate_result = self._tf_jit_calculate_result
+            elif backend == "jax":
+                if not hasattr(self, "_jax_jit_calculate_grid"):
+                    import jax
+
+                    self._jax_jit_calculate_grid = jax.jit(
+                        self.calculate_grid, static_argnames=["N"]
+                    )
+                    self._jax_jit_calculate_result = jax.jit(
+                        self.calculate_result, static_argnames=["dim", "n_per_dim"]
+                    )
+                jit_calculate_grid = self._jax_jit_calculate_grid
+                jit_calculate_result = self._jax_jit_calculate_result
+
+            def compiled_integrate(fn, integration_domain):
+                grid_points, hs, n_per_dim = jit_calculate_grid(N, integration_domain)
+                function_values, _ = self.evaluate_integrand(fn, grid_points)
+                return jit_calculate_result(function_values, dim, int(n_per_dim), hs)
+
+            return compiled_integrate
+
+        elif backend == "torch":
+            # Torch requires explicit tracing with example inputs.
+            def do_compile(example_integrand):
+                import torch
+
+                # Define traceable first and third steps
+                def step1(integration_domain):
+                    grid_points, hs, n_per_dim = self.calculate_grid(
+                        N, integration_domain
+                    )
+                    return (
+                        grid_points,
+                        hs,
+                        torch.Tensor([n_per_dim]),
+                    )  # n_per_dim is constant
+
+                def step3(function_values, hs):
+                    dim = int(integration_domain.shape[0])
+                    return self.calculate_result(function_values, dim, n_per_dim, hs)
+
+                # Trace the first step
+                step1 = torch.jit.trace(step1, (integration_domain,))
+
+                # Get example input for the third step
+                grid_points, hs, n_per_dim = step1(integration_domain)
+                n_per_dim = int(n_per_dim)
+                function_values, _ = self.evaluate_integrand(
+                    example_integrand, grid_points
+                )
+
+                # Trace the third step
+                step3 = torch.jit.trace(step3, (function_values, hs))
+
+                # Define a compiled integrate function
+                def compiled_integrate(fn, integration_domain):
+                    grid_points, hs, _ = step1(integration_domain)
+                    function_values, _ = self.evaluate_integrand(fn, grid_points)
+                    result = step3(function_values, hs)
+                    return result
+
+                return compiled_integrate
+
+            # Do the compilation when the returned function is executed the
+            # first time
+            compiled_func = [None]
+
+            def lazy_compiled_integrate(fn, integration_domain):
+                if compiled_func[0] is None:
+                    compiled_func[0] = do_compile(fn)
+                return compiled_func[0](fn, integration_domain)
+
+            return lazy_compiled_integrate
+
+        raise ValueError(f"Compilation not implemented for backend {backend}")
 
     def calculate_grid(self, N, integration_domain):
         """Calculate grid points, widths and N per dim


### PR DESCRIPTION
The method JIT-compiles the evaluation point calculation and final integral calculation but not the integrand evaluation. This can be helpful in situations where it is impossible to compile integrand.