### PR TITLE
Code fixes for the get_jit_compiled_integrate method

### DIFF
--- a/torchquad/integration/utils.py
+++ b/torchquad/integration/utils.py
@@ -125,7 +125,9 @@ def _check_integration_domain(integration_domain):
             raise ValueError("integration_domain must have 2 values per boundary")
         # Skip the values check if an integrator.integrate method is JIT
         # compiled with JAX
-        if "Jaxpr" in type(integration_domain).__name__:
+        if any(
+            nam in type(integration_domain).__name__ for nam in ["Jaxpr", "JVPTracer"]
+        ):
             return dim
         boundaries_are_invalid = (
             anp.min(integration_domain[:, 1] - integration_domain[:, 0]) < 0.0

--- a/torchquad/integration/utils.py
+++ b/torchquad/integration/utils.py
@@ -230,3 +230,17 @@ class RNG:
             backend tensor: A tensor with random values for the given numerical backend
         """
         pass
+
+    def jax_get_key(self):
+        """
+        Get the current PRNGKey.
+        This function is needed for non-determinism when JIT-compiling with JAX.
+        """
+        return self._jax_key
+
+    def jax_set_key(self, key):
+        """
+        Set the PRNGKey.
+        This function is needed for non-determinism when JIT-compiling with JAX.
+        """
+        self._jax_key = key


### PR DESCRIPTION
# Description

I noticed a few problems with the new get_jit_compiled_integrate method when calculating gradients and using MonteCarlo.

* Remove the rng argument in MonteCarlo.get_jit_compiled_integrate
* jax: Do not generate the same pseudorandom numbers in MonteCarlo in each integration
* torch: Avoid .grad attribute leaf Tensor warnings in get_jit_compiled_integrate

I also changed `_check_integration_domain` to skip the value checks when jax.jit is applied after jax.grad on integrator.integrate for compiled gradient calculation. Unfortunately I couldn't find a clean way to check if the currently executing code is traced by jax.

## Related Pull Requests

- #21 
