### PR TITLE
Gradient tests: add seed for VEGAS

### DIFF
--- a/torchquad/tests/gradient_test.py
+++ b/torchquad/tests/gradient_test.py
@@ -125,6 +125,7 @@ def _run_gradient_tests(backend, precision):
     Ns_2d = [549, 121, 81, 99997, 99997]
     for integrator, N_1d, N_2d in zip(integrators, Ns_1d, Ns_2d):
         integrator_name = type(integrator).__name__
+        requires_seed = integrator_name in ["MonteCarlo", "VEGAS"]
         if backend != "torch" and integrator_name == "VEGAS":
             # Currently VEGAS supports only Torch.
             continue
@@ -135,7 +136,7 @@ def _run_gradient_tests(backend, precision):
 
         # Test gradient calculation with the one-dimensional V-shaped function
         integrate_kwargs = {"fn": _v_function, "dim": 1, "N": N_1d}
-        if integrator_name == "MonteCarlo":
+        if requires_seed:
             integrate_kwargs["seed"] = 0
         gradient, integral = _calculate_gradient(
             backend,
@@ -155,7 +156,7 @@ def _run_gradient_tests(backend, precision):
 
         # Test gradient calculation with a two-dimensional polynomial
         integrate_kwargs = {"fn": _polynomial_function, "dim": 2, "N": N_2d}
-        if integrator_name == "MonteCarlo":
+        if requires_seed:
             integrate_kwargs["seed"] = 0
         gradient, integral = _calculate_gradient(
             backend,


### PR DESCRIPTION
Sometimes (rarely) the gradient test failed. I noticed that the seed argument is missing for VEGAS. 
commit which introduced the problem: https://github.com/FHof/torchquad/commit/b340ec6005bac710051de15e9330b9e14079c7c6#diff-dee74a23c9063d25939ff969b2fe43551ff24496c88ef48d11fd08cf0cc631ae