### PR TITLE
Vectorise more VEGAS code and do not accumulate counts in VEGASStratification

### DIFF
--- a/torchquad/integration/utils.py
+++ b/torchquad/integration/utils.py
@@ -1,4 +1,7 @@
-"""This file contains various utility functions for the integrations methods."""
+"""
+Utility functions for the integrator implementations including extensions for
+autoray, which are registered when importing this file
+"""
 import sys
 from pathlib import Path
 
@@ -7,7 +10,8 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).absolute().parent.parent))
 
 from autoray import numpy as anp
-from autoray import infer_backend, get_dtype_name
+from autoray import infer_backend, get_dtype_name, register_function
+from functools import partial
 from loguru import logger
 
 # from ..utils.set_precision import _get_precision
@@ -293,3 +297,13 @@ class RNG:
         This function is needed for non-determinism when JIT-compiling with JAX.
         """
         self._jax_key = key
+
+
+# Register anp.repeat for torch
+@partial(register_function, "torch", "repeat")
+def _torch_repeat(a, repeats, axis=None):
+    import torch
+
+    # torch.repeat_interleave corresponds to np.repeat and should not be
+    # confused with torch.Tensor.repeat.
+    return torch.repeat_interleave(a, repeats, dim=axis)

--- a/torchquad/integration/vegas_stratification.py
+++ b/torchquad/integration/vegas_stratification.py
@@ -60,11 +60,7 @@ class VEGASStratification:
         # indices maps each index of weight_all_cubes to the corresponding
         # hypercube index.
         N_cubes_arange = anp.arange(self.N_cubes, dtype=nevals.dtype, like=self.backend)
-        if self.backend == "torch":
-            # autoray doesn't support repeat yet
-            indices = anp.repeat_interleave(N_cubes_arange, nevals)
-        else:
-            indices = anp.repeat(N_cubes_arange, nevals)
+        indices = anp.repeat(N_cubes_arange, nevals)
         # Reset JF and JF2, and accumulate the weights and squared weights
         # into them.
         self.JF = anp.zeros([self.N_cubes], dtype=self.dtype, like=self.backend)
@@ -162,11 +158,7 @@ class VEGASStratification:
         positions = self._get_indices(nevals_arange)
 
         # For each hypercube i, repeat its position nevals[i] times
-        if self.backend == "torch":
-            # Autoray doesn't yet support repeat.
-            position_indices = anp.repeat_interleave(nevals_arange, nevals)
-        else:
-            position_indices = anp.repeat(nevals_arange, nevals)
+        position_indices = anp.repeat(nevals_arange, nevals)
         positions = positions[position_indices, :]
 
         # Convert the positions to float, add random offsets to them and scale

--- a/torchquad/integration/vegas_stratification.py
+++ b/torchquad/integration/vegas_stratification.py
@@ -73,7 +73,7 @@ class VEGASStratification:
             self.JF[idx] = cur_weights.sum()
 
             # Store counts
-            self.strat_counts[idx] += len(cur_weights)
+            self.strat_counts[idx] = len(cur_weights)
             prev = indices[idx]
 
         return self.JF, self.JF2

--- a/torchquad/tests/vegas_map_test.py
+++ b/torchquad/tests/vegas_map_test.py
@@ -130,7 +130,7 @@ def _run_vegas_map_checks(backend, precision):
     _check_tensor_similarity(
         anp.sum(vegasmap.dx_edges, axis=1),
         integration_domain_sizes,
-        0.0,
+        3e-7,
         dtype_float,
     )
     assert anp.min(vegasmap.dx_edges) > 0.0, "Non-positive edge distance"

--- a/torchquad/tests/vegas_map_test.py
+++ b/torchquad/tests/vegas_map_test.py
@@ -108,24 +108,10 @@ def _run_vegas_map_checks(backend, precision):
         dtype=dtype_float,
         like=backend,
     )
-    summed_weights_expected = anp.array(
-        [2.8653219, 2.2295702],
-        dtype=dtype_float,
-        like=backend,
-    )
-    delta_weights_expected = anp.array(
-        [0.47755364, 0.37159503],
-        dtype=dtype_float,
-        like=backend,
-    )
-    smoothed_weights, summed_weights, delta_weights = VEGASMap._smooth_map(
-        weights, counts, alpha
-    )
+    smoothed_weights = VEGASMap._smooth_map(weights, counts, alpha)
     _check_tensor_similarity(
         smoothed_weights, smoothed_weights_expected, 3e-7, dtype_float
     )
-    _check_tensor_similarity(summed_weights, summed_weights_expected, 3e-7, dtype_float)
-    _check_tensor_similarity(delta_weights, delta_weights_expected, 3e-7, dtype_float)
 
     # Test if vegasmap.update_map changes the edge locations and distances
     # correctly

--- a/torchquad/tests/vegas_test.py
+++ b/torchquad/tests/vegas_test.py
@@ -154,7 +154,7 @@ def _run_vegas_accuracy_checks(backend, precision):
             integration_domain=integration_domain,
             seed=seed,
         )
-        assert anp.abs(integral - reference_integral) < 0.03
+        assert anp.abs(integral - reference_integral) < 0.06
 
 
 def _run_vegas_tests(backend, precision):


### PR DESCRIPTION
I found the `torch.scatter_add_` and `torch.repeat_interleave` functions with which I could vectorise many operations. Integrating a simple 4D function with N=300000 is now a lot faster (see https://github.com/FHof/torchquad/issues/13#issuecomment-1020210140).

I noticed that with a high N, e.g. N=5000000, sometimes (randomly) indexing errors happen and I do not yet know the reason for this. I didn't test it before the vectorisation changes because VEGAS was very slow with a high N, and VEGAS is non-deterministic.
Here is an example error message: [vegasmap_getX_error.txt](https://github.com/FHof/torchquad/files/7926481/vegasmap_getX_error.txt)

Changes in this PR:
* Do not accumulate counts in VEGASStratification    
  The diagonal peaks test has a higher error now. Accumulating self.strat_counts might have led to a momentum (or something similar) in the d_tmp calculation in update_DH, which makes the stratification more aggressive.
  * Commit where the strat_counts-only accumulation was introduced: https://github.com/ESA/torchquad/commit/154aa7220377ddcbd28c4c617162a2c64d33cb8a#diff-043ebca7e1b0e1177dca8d0ce7bca0efc00f0a68c90edeea6b272ff39505e0e2L41
  * Calculation in VegasFlow: https://github.com/N3PDF/vegasflow/blob/21209c928d07c00ae4f789d03b83e518621f174a/src/vegasflow/vflowplus.py#L202
  * Calculation in original VEGAS+: https://github.com/gplepage/vegas/blob/11f67af45c8fc5c8c25060f18a61137274a64789/src/vegas/_vegas.pyx#L1645
  * Calculation in the code on which torchquad's VEGAS is based on: https://github.com/ycwu1030/CIGAR/blob/801bb6a0edf9015363be93e0e5b7d003efeccc17/src/VEGAS_Stratify.cpp#L66
    In comparison to the other implementations, here the `counts`, `JF` and `JF2` are probably initialized to 0 with `VEGAS_Stratify::Reset_Storage` and then never again reset to 0
* Remove unneeded member variables in VEGASMap
* VEGAS code vectorisations
  * Faster `VEGASMap.accumulate_weight`, `VEGASStratification.accumulate_weight` and `VEGASMap.update_map` with `torch.scatter_add_`
    I added the `_add_at_indices` function which uses indicator matrices with numpy and `scatter_add_` with torch.
    With numpy the `accumulate_weight` methods are faster now and `VEGASMap.update_map` is slower.
  * Use a broadcasted division in `VEGASStratification._get_indices` instead of a Python for loop
  * Use broadcasting, `ones` and `linspace` in the VEGASMap `x_edges` and `dx_edges` initialisation
  * Avoid a Python for loop in `VEGASStratification.get_Y` with `torch.repeat_interleave`
  * Replace Python's `sum` with `anp.sum` in `VEGASStratification.update_DH`
* Register anp.repeat for torch when importing utils.py
  With this there are no case distinctions necessary when using numpy.repeat or torch.repeat_interleave with anp.

I included the "VEGASStratification: Do not accumulate counts" commit in this PR because it's a simple two-line change and the code is overwritten again in the "VEGAS code vectorisations" commit. 