### PR TITLE
Documentation and installation requirement changes

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -45,7 +45,7 @@ jobs:
     #     flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Install dependencies
       run: |
-        $CONDA/bin/conda env update --file environment.yml --name base
+        $CONDA/bin/conda env update --file environment_all_backends.yml --name base
     - name: Test with pytest
       run: |
         cd torchquad/tests

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 *** Based on https://github.com/othneildrew/Best-README-Template
 -->
 
-![Read the Docs (version)](https://img.shields.io/readthedocs/torchquad/main?style=flat-square) ![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/esa/torchquad/Running%20tests/main?style=flat-square) ![GitHub last commit](https://img.shields.io/github/last-commit/esa/torchquad?style=flat-square) 
-![GitHub](https://img.shields.io/github/license/esa/torchquad?style=flat-square) ![Conda (channel only)](https://img.shields.io/conda/vn/conda-forge/torchquad?style=flat-square) ![PyPI](https://img.shields.io/pypi/v/torchquad?style=flat-square) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/torchquad?style=flat-square) 
+![Read the Docs (version)](https://img.shields.io/readthedocs/torchquad/main?style=flat-square) ![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/esa/torchquad/Running%20tests/main?style=flat-square) ![GitHub last commit](https://img.shields.io/github/last-commit/esa/torchquad?style=flat-square)
+![GitHub](https://img.shields.io/github/license/esa/torchquad?style=flat-square) ![Conda (channel only)](https://img.shields.io/conda/vn/conda-forge/torchquad?style=flat-square) ![PyPI](https://img.shields.io/pypi/v/torchquad?style=flat-square) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/torchquad?style=flat-square)
 
 ![GitHub contributors](https://img.shields.io/github/contributors/esa/torchquad?style=flat-square)
-![GitHub issues](https://img.shields.io/github/issues/esa/torchquad?style=flat-square) ![GitHub pull requests](https://img.shields.io/github/issues-pr/esa/torchquad?style=flat-square) 
-![Conda](https://img.shields.io/conda/dn/conda-forge/torchquad?style=flat-square) ![PyPI - Downloads](https://img.shields.io/pypi/dm/torchquad?style=flat-square) 
+![GitHub issues](https://img.shields.io/github/issues/esa/torchquad?style=flat-square) ![GitHub pull requests](https://img.shields.io/github/issues-pr/esa/torchquad?style=flat-square)
+![Conda](https://img.shields.io/conda/dn/conda-forge/torchquad?style=flat-square) ![PyPI - Downloads](https://img.shields.io/pypi/dm/torchquad?style=flat-square)
 [![JOSS](https://joss.theoj.org/papers/d6f22f83f1a889ddf83b3c2e0cd0919c/status.svg)](https://joss.theoj.org/papers/d6f22f83f1a889ddf83b3c2e0cd0919c?style=flat-square)
 
 <!-- PROJECT LOGO -->
@@ -66,7 +66,7 @@
 <!-- ABOUT THE PROJECT -->
 ## About The Project
 
-The torchquad module allows utilizing GPUs for efficient numerical integration with [PyTorch](https://pytorch.org/). 
+The torchquad module allows utilizing GPUs for efficient numerical integration with [PyTorch](https://pytorch.org/).
 The software is free to use and is designed for the machine learning community and research groups focusing on topics requiring high-dimensional integration.
 
 ### Built With
@@ -82,7 +82,7 @@ This project is built with the following packages:
 
 * **Progressing science**:  Multidimensional integration is needed in many fields of physics (from particle physics to astrophysics), in applied finance, in medical statistics, and so on. With torchquad, we wish to reach research groups in such fields, as well as the general machine learning community.
 * **Withstanding the curse of dimensionality**: The [curse of dimensionality](https://en.wikipedia.org/wiki/Curse_of_dimensionality) makes deterministic methods in particular, but also stochastic ones, extremely slow when the dimensionality increases. This gives the researcher a choice between computationally heavy and time-consuming simulations on the one hand and inaccurate evaluations on the other. Luckily, many integration methods are [embarrassingly parallel](https://en.wikipedia.org/wiki/Embarrassingly_parallel), which means they can strongly benefit from GPU parallelization. The curse of dimensionality still applies, but GPUs can handle the problem much better than CPUs can.
-* **Delivering a convenient and functional tool**: torchquad is built with [PyTorch](https://pytorch.org/), which means it is [fully differentiable](https://en.wikipedia.org/wiki/Differentiable_programming). Furthermore, the library of available and upcoming methods in torchquad offers high-effeciency integration for any need. 
+* **Delivering a convenient and functional tool**: torchquad is built with [PyTorch](https://pytorch.org/), which means it is [fully differentiable](https://en.wikipedia.org/wiki/Differentiable_programming). Furthermore, the library of available and upcoming methods in torchquad offers high-effeciency integration for any need.
 
 
 <!-- GETTING STARTED -->
@@ -99,28 +99,28 @@ For a detailed list of required packages, please refer to the [conda environment
 
 ### Installation
 
-The easiest way to install torchquad is simply to 
+The easiest way to install torchquad is simply to
 
    ```sh
    conda install torchquad -c conda-forge -c pytorch
    ```
 
-Note that since PyTorch is not yet on *conda-forge* for Windows, we have explicitly included it here using `-c pytorch`.  
+Note that since PyTorch is not yet on *conda-forge* for Windows, we have explicitly included it here using `-c pytorch`.
 
 Alternatively, it is also possible to use
    ```sh
    pip install torchquad
    ```
 
-NB Note that *pip* will **not** set up PyTorch with CUDA and GPU support. Therefore, we recommend to use *conda*. 
+NB Note that *pip* will **not** set up PyTorch with CUDA and GPU support. Therefore, we recommend to use *conda*.
 
-### Test 
+### Test
 
 After installing `torchquad` through `conda` or `pip`, users can test its correct installation with:
 
 ```py
 import torchquad
-torchquad._deployment_test() 
+torchquad._deployment_test()
 ```
 
 After cloning the repository, developers can check the functionality of `torchquad` by running the following command in the `torchquad/tests` directory:
@@ -131,7 +131,7 @@ pytest
 
 **GPU Utilization**
 
-With *conda* you can install the GPU version of PyTorch with `conda install pytorch cudatoolkit -c pytorch`. 
+With *conda* you can install the GPU version of PyTorch with `conda install pytorch cudatoolkit -c pytorch`.
 For alternative installation procedures please refer to the [PyTorch Documentation](https://pytorch.org/get-started/locally/).
 
 
@@ -143,7 +143,7 @@ This is a brief example how torchquad can be used to compute a simple integral. 
 The full documentation can be found on [readthedocs](https://torchquad.readthedocs.io/en/main/).
 
 ```python
-# To avoid copying things to GPU memory, 
+# To avoid copying things to GPU memory,
 # ideally allocate everything in torch on the GPU
 # and avoid non-torch function calls
 import torch
@@ -156,12 +156,12 @@ set_up_backend("torch", data_type="float32")
 # Note that the function needs to support multiple evaluations at once (first dimension of x here)
 # Expected result here is ~3.2698
 def some_function(x):
-    return torch.sin(x[:,0]) + torch.exp(x[:,1]) 
+    return torch.sin(x[:,0]) + torch.exp(x[:,1])
 
 # Declare an integrator, here we use the simple, stochastic Monte Carlo integration method
 mc = MonteCarlo()
 
-# Compute the function integral by sampling 10000 points over domain 
+# Compute the function integral by sampling 10000 points over domain
 integral_value = mc.integrate(some_function,dim=2,N=10000,integration_domain = [[0,1],[-1,1]])
 ```
 To change the logger verbosity, set the `TORCHQUAD_LOG_LEVEL` environment
@@ -191,9 +191,9 @@ Using GPUs torchquad scales particularly well with integration methods that offe
 
 The project is open to community contributions. Feel free to open an [issue](https://github.com/esa/torchquad/issues) or write us an email if you would like to discuss a problem or idea first.
 
-If you want to contribute, please 
+If you want to contribute, please
 
-1. Fork the project on [GitHub](https://github.com/esa/torchquad). 
+1. Fork the project on [GitHub](https://github.com/esa/torchquad).
 2. Get the most up-to-date code by following this quick guide for installing torchquad from source:
      1. Get [miniconda](https://docs.conda.io/en/latest/miniconda.html) or similar
      2. Clone the repo
@@ -219,7 +219,7 @@ Please note that PRs should be created from and into the `develop` branch. For e
 5. Push to the Branch (`git push origin feature/AmazingFeature`)
 6. Open a Pull Request on the `develop` branch, *not* `main` (NB: We autoformat every PR with black. Our GitHub actions may create additional commits on your PR for that reason.)
 
-and we will have a look at your contribution as soon as we can. 
+and we will have a look at your contribution as soon as we can.
 
 Furthermore, please make sure that your PR passes all automated tests. Review will only happen after that.
 Only PRs created on the `develop` branch with all tests passing will be considered. The only exception to this rule is if you want to update the documentation in relation to the current release on conda / pip. In that case you may ask to merge directly into `main`.
@@ -231,7 +231,7 @@ Distributed under the GPL-3.0 License. See [LICENSE](https://github.com/esa/torc
 
 
 <!-- FAQ -->
-## FAQ 
+## FAQ
 
   1. Q: `Error enabling CUDA. cuda.is_available() returned False. CPU will be used.`  <br/>A: This error indicates that no CUDA-compatible GPU could be found. Either you have no compatible GPU or the necessary CUDA requirements are missing. Using `conda`, you can install them with `conda install cudatoolkit`. For more detailed installation instructions, please refer to the [PyTorch documentation](https://pytorch.org/get-started/locally/).
 
@@ -239,7 +239,7 @@ Distributed under the GPL-3.0 License. See [LICENSE](https://github.com/esa/torc
 
 
 <!-- CONTACT -->
-## Contact 
+## Contact
 
 Created by ESA's [Advanced Concepts Team](https://www.esa.int/gsp/ACT/index.html)
 
@@ -251,6 +251,6 @@ Project Link: [https://github.com/esa/torchquad](https://github.com/esa/torchqua
 
 
 
-<!-- ACKNOWLEDGEMENTS 
+<!-- ACKNOWLEDGEMENTS
 This README was based on https://github.com/othneildrew/Best-README-Template
 -->

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
     <img src="logos/torchquad_white_background_PNG.png" alt="Logo" width="280" height="120">
   </a>
   <p align="center">
-    High-performance numerical integration on the GPU with PyTorch
+    High-performance numerical integration on the GPU with PyTorch, JAX and Tensorflow
     <br />
     <a href="https://torchquad.readthedocs.io"><strong>Explore the docs »</strong></a>
     <br />
@@ -66,15 +66,15 @@
 <!-- ABOUT THE PROJECT -->
 ## About The Project
 
-The torchquad module allows utilizing GPUs for efficient numerical integration with [PyTorch](https://pytorch.org/).
+The torchquad module allows utilizing GPUs for efficient numerical integration with [PyTorch](https://pytorch.org/) and other numerical Python3 modules.
 The software is free to use and is designed for the machine learning community and research groups focusing on topics requiring high-dimensional integration.
 
 ### Built With
 
 This project is built with the following packages:
 
-* [PyTorch](https://pytorch.org/), which means it is fully differentiable and can be used for machine learning, and
-* [conda](https://docs.conda.io/en/latest/), which will take care of all requirements for you.
+* [autoray](https://github.com/jcmgray/autoray), which means the implemented quadrature supports [NumPy](https://numpy.org/) and can be used for machine learning with modules such as [PyTorch](https://pytorch.org/), [JAX](https://github.com/google/jax/) and [Tensorflow](https://www.tensorflow.org/), where it is fully differentiable
+* [conda](https://docs.conda.io/en/latest/), which will take care of all requirements for you
 
 
 <!-- GOALS -->
@@ -82,7 +82,7 @@ This project is built with the following packages:
 
 * **Progressing science**:  Multidimensional integration is needed in many fields of physics (from particle physics to astrophysics), in applied finance, in medical statistics, and so on. With torchquad, we wish to reach research groups in such fields, as well as the general machine learning community.
 * **Withstanding the curse of dimensionality**: The [curse of dimensionality](https://en.wikipedia.org/wiki/Curse_of_dimensionality) makes deterministic methods in particular, but also stochastic ones, extremely slow when the dimensionality increases. This gives the researcher a choice between computationally heavy and time-consuming simulations on the one hand and inaccurate evaluations on the other. Luckily, many integration methods are [embarrassingly parallel](https://en.wikipedia.org/wiki/Embarrassingly_parallel), which means they can strongly benefit from GPU parallelization. The curse of dimensionality still applies, but GPUs can handle the problem much better than CPUs can.
-* **Delivering a convenient and functional tool**: torchquad is built with [PyTorch](https://pytorch.org/), which means it is [fully differentiable](https://en.wikipedia.org/wiki/Differentiable_programming). Furthermore, the library of available and upcoming methods in torchquad offers high-effeciency integration for any need.
+* **Delivering a convenient and functional tool**: torchquad is built with autoray, which means it is [fully differentiable](https://en.wikipedia.org/wiki/Differentiable_programming) if the user chooses, for example, PyTorch as the numerical backend. Furthermore, the library of available and upcoming methods in torchquad offers high-effeciency integration for any need.
 
 
 <!-- GETTING STARTED -->
@@ -92,31 +92,55 @@ This is a brief guide for how to set up torchquad.
 
 ### Prerequisites
 
-We recommend using [conda](https://anaconda.org/conda-forge/torchquad), especially if you want to utilize the GPU. It will automatically set up CUDA and the cudatoolkit for you in that case.
+We recommend using [conda](https://anaconda.org/conda-forge/torchquad), especially if you want to utilize the GPU.
+With PyTorch it will automatically set up CUDA and the cudatoolkit for you, for example.
 Note that torchquad also works on the CPU; however, it is optimized for GPU usage. Currently torchquad only supports NVIDIA cards with CUDA. We are investigating future support for AMD cards through [ROCm](https://pytorch.org/blog/pytorch-for-amd-rocm-platform-now-available-as-python-package/).
 
-For a detailed list of required packages, please refer to the [conda environment file](https://github.com/esa/torchquad/blob/main/environment.yml).
+For a detailed list of required packages and packages for numerical backends,
+please refer to the conda environment files [environment.yml](/environment.yml) and [environment_all_backends.yml](/environment_all_backends.yml).
+torchquad has been tested with JAX 0.2.25, NumPy 1.19.5, PyTorch 1.10.0 and Tensorflow 2.7.0; other versions of the backends should work as well.
+
 
 ### Installation
 
 The easiest way to install torchquad is simply to
-
    ```sh
-   conda install torchquad -c conda-forge -c pytorch
+   conda install torchquad -c conda-forge
    ```
-
-Note that since PyTorch is not yet on *conda-forge* for Windows, we have explicitly included it here using `-c pytorch`.
 
 Alternatively, it is also possible to use
    ```sh
    pip install torchquad
    ```
 
-NB Note that *pip* will **not** set up PyTorch with CUDA and GPU support. Therefore, we recommend to use *conda*.
+The PyTorch backend with CUDA support can be installed with
+   ```sh
+   conda install "cudatoolkit>=11.1" "pytorch>=1.9=*cuda*" -c conda-forge -c pytorch
+   ```
+
+Note that since PyTorch is not yet on *conda-forge* for Windows, we have explicitly included it here using `-c pytorch`.
+Note also that installing PyTorch with *pip* may **not** set it up with CUDA support. Therefore, we recommend to use *conda*.
+
+Here are installation instructions for other numerical backends:
+   ```sh
+   conda install "tensorflow>=2.6.0=cuda*" -c conda-forge
+   pip install "jax[cuda]>=0.2.22" --find-links https://storage.googleapis.com/jax-releases/jax_releases.html
+   conda install "numpy>=1.19.5" -c conda-forge
+   ```
+
+More installation instructions for numerical backends can be found in
+[environment_all_backends.yml](/environment_all_backends.yml) and at the
+backend documentations, for example
+https://pytorch.org/get-started/locally/,
+https://github.com/google/jax/#installation and
+https://www.tensorflow.org/install/gpu, and often there are multiple ways to
+install them.
+
 
 ### Test
 
-After installing `torchquad` through `conda` or `pip`, users can test its correct installation with:
+After installing `torchquad` and PyTorch through `conda` or `pip`,
+users can test `torchquad`'s correct installation with:
 
 ```py
 import torchquad
@@ -129,20 +153,14 @@ After cloning the repository, developers can check the functionality of `torchqu
 pytest
 ```
 
-**GPU Utilization**
-
-With *conda* you can install the GPU version of PyTorch with `conda install pytorch cudatoolkit -c pytorch`.
-For alternative installation procedures please refer to the [PyTorch Documentation](https://pytorch.org/get-started/locally/).
-
-
 <!-- USAGE EXAMPLES -->
 ## Usage
 
-This is a brief example how torchquad can be used to compute a simple integral. For a more thorough introduction please refer to the [tutorial](https://torchquad.readthedocs.io/en/main/tutorial.html) section in the documentation.
+This is a brief example how torchquad can be used to compute a simple integral with PyTorch. For a more thorough introduction please refer to the [tutorial](https://torchquad.readthedocs.io/en/main/tutorial.html) section in the documentation.
 
 The full documentation can be found on [readthedocs](https://torchquad.readthedocs.io/en/main/).
 
-```python
+```Python3
 # To avoid copying things to GPU memory,
 # ideally allocate everything in torch on the GPU
 # and avoid non-torch function calls
@@ -152,17 +170,26 @@ from torchquad import MonteCarlo, set_up_backend
 # Enable GPU support if available and set the floating point precision
 set_up_backend("torch", data_type="float32")
 
-# The function we want to integrate, in this example f(x0,x1) = sin(x0) + e^x1 for x0=[0,1] and x1=[-1,1]
-# Note that the function needs to support multiple evaluations at once (first dimension of x here)
+# The function we want to integrate, in this example
+# f(x0,x1) = sin(x0) + e^x1 for x0=[0,1] and x1=[-1,1]
+# Note that the function needs to support multiple evaluations at once (first
+# dimension of x here)
 # Expected result here is ~3.2698
 def some_function(x):
-    return torch.sin(x[:,0]) + torch.exp(x[:,1])
+    return torch.sin(x[:, 0]) + torch.exp(x[:, 1])
 
-# Declare an integrator, here we use the simple, stochastic Monte Carlo integration method
+# Declare an integrator;
+# here we use the simple, stochastic Monte Carlo integration method
 mc = MonteCarlo()
 
 # Compute the function integral by sampling 10000 points over domain
-integral_value = mc.integrate(some_function,dim=2,N=10000,integration_domain = [[0,1],[-1,1]])
+integral_value = mc.integrate(
+    some_function,
+    dim=2,
+    N=10000,
+    integration_domain=[[0, 1], [-1, 1]],
+    backend="torch",
+)
 ```
 To change the logger verbosity, set the `TORCHQUAD_LOG_LEVEL` environment
 variable; for example `export TORCHQUAD_LOG_LEVEL=WARNING`.
@@ -203,11 +230,11 @@ If you want to contribute, please
      3. With the default configuration, all numerical backends with CUDA
        support are installed.
        If this should not happen, comment out unwanted packages in
-       `environment.yml`.
+       `environment_all_backends.yml`.
      4. Set up the environment. This creates a conda environment called
       `torchquad` and installs the required dependencies.
       ```sh
-      conda env create -f environment.yml
+      conda env create -f environment_all_backends.yml
       conda activate torchquad
       ```
 
@@ -233,7 +260,7 @@ Distributed under the GPL-3.0 License. See [LICENSE](https://github.com/esa/torc
 <!-- FAQ -->
 ## FAQ
 
-  1. Q: `Error enabling CUDA. cuda.is_available() returned False. CPU will be used.`  <br/>A: This error indicates that no CUDA-compatible GPU could be found. Either you have no compatible GPU or the necessary CUDA requirements are missing. Using `conda`, you can install them with `conda install cudatoolkit`. For more detailed installation instructions, please refer to the [PyTorch documentation](https://pytorch.org/get-started/locally/).
+  1. Q: `Error enabling CUDA. cuda.is_available() returned False. CPU will be used.`  <br/>A: This error indicates that PyTorch could not find a CUDA-compatible GPU. Either you have no compatible GPU or the necessary CUDA requirements are missing. Using `conda`, you can install them with `conda install cudatoolkit`. For more detailed installation instructions, please refer to the [PyTorch documentation](https://pytorch.org/get-started/locally/).
 
 
 

--- a/docs/source/autodoc.rst
+++ b/docs/source/autodoc.rst
@@ -3,14 +3,29 @@
 All content
 ======================================
 
-This is the list of all content in *torchquad*.  
+This is the list of all content in *torchquad*.
+The type *backend tensor* in the documentation is a placeholder for the tensor
+type of the current numerical backend,
+for example ``numpy.array`` or ``torch.Tensor``.
 
 We are continuously implementing new content in our library.
-For the code, please see the `code page <https://torchquad.readthedocs.io/en/main/_modules/index.html>`_ 
+For the code, please see the `code page <https://torchquad.readthedocs.io/en/main/_modules/index.html>`_
 or check out our full code and latest news at https://github.com/esa/torchquad.
 
 .. automodule:: torchquad
    :members:
    :undoc-members:
    :show-inheritance:
-   
+
+
+.. Abstract classes which are not part of __all__
+
+.. autoclass:: torchquad.integration.newton_cotes.NewtonCotes
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: torchquad.integration.base_integrator.BaseIntegrator
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,60 +14,62 @@
    :target: https://torchquad.readthedocs.io/en/main/?badge=main
    :alt: Documentation Status
 
-.. image:: https://img.shields.io/github/workflow/status/esa/torchquad/Running%20tests/develop   
-   :target: https://img.shields.io/github/workflow/status/esa/torchquad/Running%20tests/develop   
+.. image:: https://img.shields.io/github/workflow/status/esa/torchquad/Running%20tests/develop
+   :target: https://img.shields.io/github/workflow/status/esa/torchquad/Running%20tests/develop
    :alt: GitHub Workflow Status (branch)
 
-.. image:: https://img.shields.io/github/last-commit/esa/torchquad   
-   :target: https://img.shields.io/github/last-commit/esa/torchquad   
+.. image:: https://img.shields.io/github/last-commit/esa/torchquad
+   :target: https://img.shields.io/github/last-commit/esa/torchquad
    :alt: GitHub last commit
 
-.. image:: https://img.shields.io/github/license/esa/torchquad   
-   :target: https://img.shields.io/github/license/esa/torchquad   
+.. image:: https://img.shields.io/github/license/esa/torchquad
+   :target: https://img.shields.io/github/license/esa/torchquad
    :alt: GitHub license
 
-.. image:: https://img.shields.io/conda/vn/conda-forge/torchquad   
-   :target: https://img.shields.io/conda/vn/conda-forge/torchquad   
+.. image:: https://img.shields.io/conda/vn/conda-forge/torchquad
+   :target: https://img.shields.io/conda/vn/conda-forge/torchquad
    :alt: Conda (channel only)
 
-.. image:: https://img.shields.io/pypi/v/torchquad   
-   :target: https://img.shields.io/pypi/v/torchquad   
+.. image:: https://img.shields.io/pypi/v/torchquad
+   :target: https://img.shields.io/pypi/v/torchquad
    :alt: PyPI Version
 
-.. image:: https://img.shields.io/pypi/pyversions/torchquad   
-   :target: https://img.shields.io/pypi/pyversions/torchquad   
+.. image:: https://img.shields.io/pypi/pyversions/torchquad
+   :target: https://img.shields.io/pypi/pyversions/torchquad
    :alt: PyPI - Python Version
 
-.. image:: https://img.shields.io/github/contributors/esa/torchquad   
-   :target: https://img.shields.io/github/contributors/esa/torchquad  
+.. image:: https://img.shields.io/github/contributors/esa/torchquad
+   :target: https://img.shields.io/github/contributors/esa/torchquad
    :alt: GitHub contributors
 
-.. image:: https://img.shields.io/github/issues/esa/torchquad   
-   :target: https://img.shields.io/github/issues/esa/torchquad    
-   :alt: GitHub issues 
+.. image:: https://img.shields.io/github/issues/esa/torchquad
+   :target: https://img.shields.io/github/issues/esa/torchquad
+   :alt: GitHub issues
 
-.. image:: https://img.shields.io/github/issues-pr/esa/torchquad   
+.. image:: https://img.shields.io/github/issues-pr/esa/torchquad
    :target: https://img.shields.io/github/issues-pr/esa/torchquad
    :alt: GitHub pull requests
 
-.. image:: https://img.shields.io/conda/dn/conda-forge/torchquad   
+.. image:: https://img.shields.io/conda/dn/conda-forge/torchquad
    :target: https://img.shields.io/conda/dn/conda-forge/torchquad
    :alt: Conda
 
-.. image:: https://img.shields.io/pypi/dm/torchquad   
+.. image:: https://img.shields.io/pypi/dm/torchquad
    :target: https://img.shields.io/pypi/dm/torchquad
    :alt: PyPI - Downloads
 
-.. image:: https://joss.theoj.org/papers/d6f22f83f1a889ddf83b3c2e0cd0919c/status.svg   
+.. image:: https://joss.theoj.org/papers/d6f22f83f1a889ddf83b3c2e0cd0919c/status.svg
    :target: https://joss.theoj.org/papers/d6f22f83f1a889ddf83b3c2e0cd0919c
    :alt: JOSS Status
-   
+
 
 Welcome to torchquad's documentation!
 =====================================================
 
-*torchquad* is a Python module for multidimensional numerical integration on the GPU 
-using `PyTorch <https://pytorch.org/>`_.
+*torchquad* is a Python3 module for multidimensional numerical integration on the GPU.
+It uses `autoray <https://github.com/jcmgray/autoray>`_ to support
+`PyTorch <https://pytorch.org/>`_ and
+:ref:`other machine learning modules <tutorial_backend_selection>`.
 
 You can see the latest code at https://github.com/esa/torchquad.
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -5,32 +5,34 @@ Getting started
 
 This is a brief introduction on how to set up *torchquad*.
 
-Prerequisites 
+Prerequisites
 --------------
 
 *torchquad* is built with
 
-- `PyTorch <https://pytorch.org/>`_, which means it is fully differentiable and can be used for machine learning, and
-- `conda <https://docs.conda.io/en/latest/>`_, which will take care of all requirements for you.
+- `autoray <https://github.com/jcmgray/autoray>`_, which means the implemented quadrature supports `NumPy <https://numpy.org/>`_ and can be used for machine learning with modules such as `PyTorch <https://pytorch.org/>`_, `JAX <https://github.com/google/jax/>`_ and `Tensorflow <https://www.tensorflow.org/>`_, where it is fully differentiable
+- `conda <https://docs.conda.io/en/latest/>`_, which will take care of all requirements for you
 
-We recommend using `conda <https://docs.conda.io/en/latest/>`_, especially if you want to utilize the GPU. 
-It will automatically set up CUDA and the cudatoolkit for you in that case.
-Note that *torchquad* also works on the CPU; however, it is optimized for GPU usage. 
-Currently torchquad only supports NVIDIA cards with CUDA. We are investigating future support for AMD cards through [ROCm](https://pytorch.org/blog/pytorch-for-amd-rocm-platform-now-available-as-python-package/).
+We recommend using `conda <https://docs.conda.io/en/latest/>`_, especially if you want to utilize the GPU.
+With PyTorch it will automatically set up CUDA and the cudatoolkit for you, for example.
+Note that *torchquad* also works on the CPU; however, it is optimized for GPU usage.
+Currently torchquad only supports NVIDIA cards with CUDA. We are investigating future support for AMD cards through `ROCm <https://pytorch.org/blog/pytorch-for-amd-rocm-platform-now-available-as-python-package/>`_.
 
-For a detailed list of required packages, please refer to the `conda environment file <https://github.com/esa/torchquad/blob/main/environment.yml>`_.
+For a detailed list of required packages and packages for numerical backends,
+please refer to the conda environment files `environment.yml <https://github.com/esa/torchquad/blob/main/environment.yml>`_ and
+`environment_all_backends.yml <https://github.com/esa/torchquad/blob/main/environment_all_backends.yml>`_.
+torchquad has been tested with JAX 0.2.25, NumPy 1.19.5, PyTorch 1.10.0 and Tensorflow 2.7.0; other versions of the backends should work as well.
+
 
 Installation
 -------------
 
-First, we must make sure we have `torchquad <https://github.com/esa/torchquad>`_ installed. 
-The easiest way to do this is simply to 
+First, we must make sure we have `torchquad <https://github.com/esa/torchquad>`_ installed.
+The easiest way to do this is simply to
 
    .. code-block:: bash
 
-      conda install torchquad -c conda-forge -c pytorch
-
-Note that since PyTorch is not yet on *conda-forge* for Windows, we have explicitly included it here using ``-c pytorch``.  
+      conda install torchquad -c conda-forge
 
 Alternatively, it is also possible to use
 
@@ -38,16 +40,38 @@ Alternatively, it is also possible to use
 
       pip install torchquad
 
-NB Note that *pip* will **not** set up PyTorch with CUDA and GPU support. Therefore, we recommend to use *conda*. 
+The PyTorch backend with CUDA support can be installed with
 
-**GPU Utilization**
+   .. code-block:: bash
 
-With *conda* you can install the GPU version of PyTorch with ``conda install pytorch cudatoolkit -c pytorch``. 
-For alternative installation procedures please refer to the `PyTorch Documentation <https://pytorch.org/get-started/locally/>`_.
+      conda install "cudatoolkit>=11.1" "pytorch>=1.9=*cuda*" -c conda-forge -c pytorch
+
+Note that since PyTorch is not yet on *conda-forge* for Windows, we have
+explicitly included it here using ``-c pytorch``.
+Note also that installing PyTorch with *pip* may **not** set it up with CUDA
+support.
+Therefore, we recommend to use *conda*.
+
+Here are installation instructions for other numerical backends:
+
+   .. code-block:: bash
+
+      conda install "tensorflow>=2.6.0=cuda*" -c conda-forge
+      pip install "jax[cuda]>=0.2.22" --find-links https://storage.googleapis.com/jax-releases/jax_releases.html
+      conda install "numpy>=1.19.5" -c conda-forge
+
+More installation instructions for numerical backends can be found in
+`environment_all_backends.yml <https://github.com/esa/torchquad/blob/main/environment_all_backends.yml>`__
+and at the backend documentations, for example
+https://pytorch.org/get-started/locally/,
+https://github.com/google/jax/#installation and
+https://www.tensorflow.org/install/gpu, and often there are multiple
+ways to install them.
+
 
 Usage
 -----
 
-Now you are ready to use *torchquad*. 
-A brief example of how *torchquad* can be used to compute a simple integral can be found on our `GitHub <https://github.com/esa/torchquad#usage>`_. 
+Now you are ready to use *torchquad*.
+A brief example of how *torchquad* can be used to compute a simple integral can be found on our `GitHub <https://github.com/esa/torchquad#usage>`_.
 For a more thorough introduction, please refer to the `tutorial <https://torchquad.readthedocs.io/en/main/tutorial.html>`_.

--- a/docs/source/integration_methods.rst
+++ b/docs/source/integration_methods.rst
@@ -4,7 +4,7 @@ Integration methods
 This is the list of all available integration methods in *torchquad*.
 
 We are continuously implementing new methods in our library.
-For the code behind the integration methods, please see the `code page <https://torchquad.readthedocs.io/en/main/_modules/index.html>`_ 
+For the code behind the integration methods, please see the `code page <https://torchquad.readthedocs.io/en/main/_modules/index.html>`_
 or check out our full code and latest news at https://github.com/esa/torchquad.
 
 .. contents::
@@ -16,16 +16,16 @@ Monte Carlo Integrator
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchquad.MonteCarlo
-   :members:
+   :members: integrate
    :noindex:
 
 VEGAS Enhanced
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchquad.VEGAS
-   :members:
+   :members: integrate
    :noindex:
-   
+
 Deterministic Methods
 ----------------------
 
@@ -33,15 +33,15 @@ Boole's Rule
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchquad.Boole
-   :members:
+   :members: integrate
    :noindex:
-   
+
 
 Simpson's Rule
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchquad.Simpson
-   :members:
+   :members: integrate
    :noindex:
 
 
@@ -49,5 +49,5 @@ Trapezoid Rule
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: torchquad.Trapezoid
-   :members:
+   :members: integrate
    :noindex:

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,6 @@
 name: torchquad
 channels:
 - conda-forge
-- pytorch
 dependencies:
 - autoray>=0.2.5
 - loguru>=0.5.3
@@ -12,12 +11,3 @@ dependencies:
 - sphinx>=3.4.3
 - sphinx_rtd_theme>=0.5.1
 - tqdm>=4.56.0
-# Numerical backend installations with CUDA support where possible:
-- numpy>=1.19.5
-- cudatoolkit>=11.1
-- pytorch>=1.9=*cuda*
-- tensorflow>=2.6.0=cuda*
-# jaxlib with CUDA support is not available for conda
-- pip:
-  - --find-links https://storage.googleapis.com/jax-releases/jax_releases.html
-  - jax[cuda]>=0.2.22

--- a/environment_all_backends.yml
+++ b/environment_all_backends.yml
@@ -1,0 +1,24 @@
+# A conda environment file to install all supported numerical backends
+name: torchquad
+channels:
+- conda-forge
+- pytorch
+dependencies:
+- autoray>=0.2.5
+- loguru>=0.5.3
+- matplotlib>=3.3.3
+- pytest>=6.2.1
+- python>=3.8
+- scipy>=1.6.0
+- sphinx>=3.4.3
+- sphinx_rtd_theme>=0.5.1
+- tqdm>=4.56.0
+# Numerical backend installations with CUDA support where possible:
+- numpy>=1.19.5
+- cudatoolkit>=11.1
+- pytorch>=1.9=*cuda*
+- tensorflow>=2.6.0=cuda*
+# jaxlib with CUDA support is not available for conda
+- pip:
+  - --find-links https://storage.googleapis.com/jax-releases/jax_releases.html
+  - jax[cuda]>=0.2.22

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 loguru>=0.5.3
 matplotlib>=3.3.3
-torch==1.9.0
+autoray>=0.2.5
 scipy>=1.6.0
 tqdm>=4.56.0

--- a/rtd_environment.yml
+++ b/rtd_environment.yml
@@ -1,14 +1,13 @@
 name: rtd_torchquad
 channels:
 - conda-forge
-- pytorch
 dependencies:
 - ipython
 - loguru>=0.5.3
 - matplotlib>=3.3.3
 - pytest>=6.2.1
 - python>=3.8
-- pytorch>=1.9
+- autoray>=0.2.5
 - scipy>=1.6.0
 - sphinx>=3.4.3
 - sphinx_rtd_theme>=0.5.1

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         "matplotlib>=3.3.3",
         "scipy>=1.6.0",
         "tqdm>=4.56.1",
-        "torch>=1.7.1",
+        "autoray>=0.2.5",
     ],
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/torchquad/integration/monte_carlo.py
+++ b/torchquad/integration/monte_carlo.py
@@ -228,7 +228,7 @@ class MonteCarlo(BaseIntegrator):
         # Integral = V / N * sum(func values)
         N = function_values.shape[0]
         integral = volume * anp.sum(function_values) / N
-        # Numpy automatically casts to float64 when dividing by N
+        # NumPy automatically casts to float64 when dividing by N
         if (
             infer_backend(integration_domain) == "numpy"
             and function_values.dtype != integral.dtype

--- a/torchquad/integration/utils.py
+++ b/torchquad/integration/utils.py
@@ -120,7 +120,7 @@ def _setup_integration_domain(dim, integration_domain, backend):
         ]
         dtype_arg = _get_precision(backend)
         if dtype_arg is not None:
-            # For Numpy and Tensorflow there is no global dtype, so set the
+            # For NumPy and Tensorflow there is no global dtype, so set the
             # configured default dtype here
             integration_domain = anp.array(
                 integration_domain, like=backend, dtype=dtype_arg
@@ -197,21 +197,23 @@ class RNG:
     A random number generator helper class for multiple numerical backends
 
     Notes:
-    * The seed argument may behave differently in different versions of a
-      numerical backend and when using GPU instead of CPU
-      * https://pytorch.org/docs/stable/notes/randomness.html
-      * https://numpy.org/doc/stable/reference/random/generator.html#numpy.random.Generator
-      * https://www.tensorflow.org/api_docs/python/tf/random/Generator
-        Only the Philox RNG guarantees consistent behaviour in Tensorflow.
-    * For torch, the RNG state is global, so if VEGAS integration uses this and
-      the integrand itself generates random numbers and changes the seed,
-      the calculated grid points may no longer be random.
-      Torch allows to fork the RNG, but this may be slow.
-    * Often uniform random numbers are generated in [0, 1) instead of [0, 1].
-      * numpy: random() is in [0, 1) and uniform() in [0, 1]
-      * JAX: uniform() is in [0, 1)
-      * torch: rand() is in [0, 1)
-      * tensorflow: uniform() is in [0, 1)
+        - The seed argument may behave differently in different versions of a
+          numerical backend and when using GPU instead of CPU
+
+            - https://pytorch.org/docs/stable/notes/randomness.html
+            - https://numpy.org/doc/stable/reference/random/generator.html#numpy.random.Generator
+            - https://www.tensorflow.org/api_docs/python/tf/random/Generator
+              Only the Philox RNG guarantees consistent behaviour in Tensorflow.
+        - For torch, the RNG state is global, so if VEGAS integration uses this and
+          the integrand itself generates random numbers and changes the seed,
+          the calculated grid points may no longer be random.
+          Torch allows to fork the RNG, but this may be slow.
+        - Often uniform random numbers are generated in [0, 1) instead of [0, 1].
+
+            - numpy: random() is in [0, 1) and uniform() in [0, 1]
+            - JAX: uniform() is in [0, 1)
+            - torch: rand() is in [0, 1)
+            - tensorflow: uniform() is in [0, 1)
     """
 
     def __init__(self, backend, seed=None):

--- a/torchquad/integration/vegas.py
+++ b/torchquad/integration/vegas.py
@@ -42,6 +42,8 @@ class VEGAS(BaseIntegrator):
     ):
         """Integrates the passed function on the passed domain using VEGAS.
 
+        If the integrand output is far away from zero, i.e. lies within [b, b+c] for a constant b with large absolute value and small constant c, VEGAS does not adapt well to the integrand. Shifting the integrand so that it is close to zero may improve the accuracy of the calculated integral in this case.
+
         Args:
             fn (func): The function to integrate over.
             dim (int): Dimensionality of the function to integrate.
@@ -326,7 +328,7 @@ class VEGAS(BaseIntegrator):
             res_den = sum(1.0 / sig2 for sig2 in self.sigma2)
             res = res_num / res_den
         if self.backend == "numpy" and res.dtype != self.results[0].dtype:
-            # Numpy automatically casts float32 to float64 in the above
+            # NumPy automatically casts float32 to float64 in the above
             # calculations
             res = astype(res, self.results[0].dtype)
         return res

--- a/torchquad/utils/set_precision.py
+++ b/torchquad/utils/set_precision.py
@@ -3,7 +3,7 @@ import os
 
 
 def _get_precision(backend):
-    """Get the configured default precision for Numpy or Tensorflow.
+    """Get the configured default precision for NumPy or Tensorflow.
 
     Args:
         backend ("numpy" or "tensorflow"): Numerical backend
@@ -17,7 +17,7 @@ def _get_precision(backend):
 def set_precision(data_type="float32", backend="torch"):
     """This function allows the user to set the default precision for floating point numbers for the given numerical backend.
     Call before declaring your variables.
-    Numpy and Tensorflow don't have global dtypes:
+    NumPy and Tensorflow don't have global dtypes:
     https://github.com/numpy/numpy/issues/6860
     https://github.com/tensorflow/tensorflow/issues/26033
     Therefore, torchquad sets the dtype argument for these two when initialising the integration domain.


### PR DESCRIPTION
To use an integrator with another numerical backend than PyTorch, for example Numpy, the only torchquad-related change needed in the example code is to pass `backend="numpy"` to the integrate method (and enabling numpy behaviour in case of Tensorflow) Other code changes are not related to torchquad, for example replacing torch.sin with np.sin in the integrand for the numpy backend or using jax.grad for gradient calculation with JAX; these operations are already well documented at other websites.

<!--
I also changed the math formula image format to SVG so that the formulas look sharp even when they are not shown in the original resolution. Here's a before and after comparison:
![latexpng](https://user-images.githubusercontent.com/23431138/152999770-2c434c35-8cee-4b07-8ffd-c28bab064165.png)
![latexsvg](https://user-images.githubusercontent.com/23431138/152999773-401eea86-6cd7-4345-b692-3f26ad57a8bb.png)
-->
