### PR TITLE
Execute black 22.1.0

### DIFF
--- a/torchquad/integration/boole.py
+++ b/torchquad/integration/boole.py
@@ -52,7 +52,7 @@ class Boole(NewtonCotes):
     @staticmethod
     def _get_minimal_N(dim):
         """Get the minimal number of points N for the integrator rule"""
-        return 5 ** dim
+        return 5**dim
 
     @staticmethod
     def _adjust_N(dim, N):
@@ -77,7 +77,7 @@ class Boole(NewtonCotes):
                 "N per dimension cannot be lower than 5. "
                 "N per dim will now be changed to 5."
             )
-            N = 5 ** dim
+            N = 5**dim
         elif (n_per_dim - 1) % 4 != 0:
             new_n_per_dim = n_per_dim - ((n_per_dim - 1) % 4)
             warnings.warn(

--- a/torchquad/integration/simpson.py
+++ b/torchquad/integration/simpson.py
@@ -50,7 +50,7 @@ class Simpson(NewtonCotes):
     @staticmethod
     def _get_minimal_N(dim):
         """Get the minimal number of points N for the integrator rule"""
-        return 3 ** dim
+        return 3**dim
 
     @staticmethod
     def _adjust_N(dim, N):
@@ -73,7 +73,7 @@ class Simpson(NewtonCotes):
                 "N per dimension cannot be lower than 3. "
                 "N per dim will now be changed to 3."
             )
-            N = 3 ** dim
+            N = 3**dim
         elif n_per_dim % 2 != 1:
             warnings.warn(
                 "N per dimension cannot be even due to necessary subdivisions. "

--- a/torchquad/integration/utils.py
+++ b/torchquad/integration/utils.py
@@ -245,7 +245,7 @@ class RNG:
                 # https://github.com/jcmgray/autoray/blob/35677037863d7d0d25ff025998d9fda75dce3b44/autoray/autoray.py#L737
                 from random import SystemRandom
 
-                seed = SystemRandom().randint(-(2 ** 63), 2 ** 63 - 1)
+                seed = SystemRandom().randint(-(2**63), 2**63 - 1)
             self._jax_key = PRNGKey(seed)
 
             def uniform_func(size, dtype):

--- a/torchquad/integration/vegas.py
+++ b/torchquad/integration/vegas.py
@@ -209,7 +209,7 @@ class VEGAS(BaseIntegrator):
             f_eval = self._eval(x).squeeze()
             jac = self.map.get_Jac(yrnd)
             jf_vec = f_eval * jac
-            jf_vec2 = jf_vec ** 2
+            jf_vec2 = jf_vec**2
             self.map.accumulate_weight(yrnd, jf_vec2)  # update map weights
             jf = jf_vec.sum()
             jf2 = jf_vec2.sum()
@@ -251,7 +251,7 @@ class VEGAS(BaseIntegrator):
 
         jac = self.map.get_Jac(y)  # compute jacobian
         jf_vec = f_eval * jac  # precompute product once
-        jf_vec2 = jf_vec ** 2
+        jf_vec2 = jf_vec**2
 
         if self.use_grid_improve:  # if adaptive map is used, acc weight
             self.map.accumulate_weight(y, jf_vec2)  # EQ 25
@@ -261,7 +261,7 @@ class VEGAS(BaseIntegrator):
         ih = jf * neval_inverse * self.strat.V_cubes  # Compute integral per cube
 
         # Collect results
-        sig2 = jf2 * neval_inverse * (self.strat.V_cubes ** 2) - pow(ih, 2)
+        sig2 = jf2 * neval_inverse * (self.strat.V_cubes**2) - pow(ih, 2)
         self.results[-1] = ih.sum()  # store results
         self.sigma2[-1] = (sig2 * neval_inverse).sum()
 

--- a/torchquad/integration/vegas_stratification.py
+++ b/torchquad/integration/vegas_stratification.py
@@ -27,7 +27,7 @@ class VEGASStratification:
         self.N_strat = int((N_increment / 4.0) ** (1.0 / dim))
         self.N_strat = 1000 if self.N_strat > 1000 else self.N_strat
         self.beta = beta  # variable controlling adaptiveness in stratification 0 to 1
-        self.N_cubes = self.N_strat ** self.dim  # total number of subdomains
+        self.N_cubes = self.N_strat**self.dim  # total number of subdomains
         self.V_cubes = (1.0 / self.N_strat) ** self.dim  # volume of hypercubes
 
         self.dtype = dtype
@@ -66,7 +66,7 @@ class VEGASStratification:
         self.JF = anp.zeros([self.N_cubes], dtype=self.dtype, like=self.backend)
         self.JF2 = anp.zeros([self.N_cubes], dtype=self.dtype, like=self.backend)
         _add_at_indices(self.JF, indices, weight_all_cubes, is_sorted=True)
-        _add_at_indices(self.JF2, indices, weight_all_cubes ** 2.0, is_sorted=True)
+        _add_at_indices(self.JF2, indices, weight_all_cubes**2.0, is_sorted=True)
 
         # Store counts
         self.strat_counts = astype(nevals, self.dtype)
@@ -87,7 +87,7 @@ class VEGASStratification:
         # Sometimes rounding errors produce negative values very close to 0
         d_tmp[d_tmp < 0.0] = 0.0
 
-        self.dh = d_tmp ** self.beta
+        self.dh = d_tmp**self.beta
 
         # Normalize dampening
         d_sum = anp.sum(self.dh)

--- a/torchquad/tests/integration_grid_test.py
+++ b/torchquad/tests/integration_grid_test.py
@@ -54,7 +54,7 @@ def _run_integration_grid_tests(backend, precision):
     # Test 1: N is float, 1-D
     # Test 2: N is int, 3-D
     # Test 3: N is float, 3-D
-    Ns = [10.0, 4 ** 3, 4.0 ** 3]
+    Ns = [10.0, 4**3, 4.0**3]
     domains = [
         [[0.0, 1.0]],
         [[0.0, 2.0], [-2.0, 1.0], [0.5, 1.0]],

--- a/torchquad/tests/integrator_types_test.py
+++ b/torchquad/tests/integrator_types_test.py
@@ -39,7 +39,7 @@ def _run_simple_integrations(backend):
       constant function (almost) exactly.
     """
     integrators_all = [Trapezoid(), Simpson(), Boole(), MonteCarlo(), VEGAS()]
-    Ns_all = [13 ** 2, 13 ** 2, 13 ** 2, 20, 1000]
+    Ns_all = [13**2, 13**2, 13**2, 20, 1000]
 
     expected_dtype_name = None
 

--- a/torchquad/tests/simpson_test.py
+++ b/torchquad/tests/simpson_test.py
@@ -59,7 +59,7 @@ def _run_simpson_tests(backend, _precision):
         return
 
     # 10D Tests
-    N = 3 ** 10
+    N = 3**10
     errors, funcs = compute_integration_test_errors(
         simp.integrate, {"N": N, "dim": 10}, dim=10, use_complex=True, backend=backend
     )

--- a/torchquad/tests/vegas_map_test.py
+++ b/torchquad/tests/vegas_map_test.py
@@ -73,13 +73,13 @@ def _run_vegas_map_checks(backend, precision):
 
     # Test get_Jac for a fresh VEGAS map
     jac = vegasmap.get_Jac(y)
-    assert jac.shape == (N_per_dim ** dim,)
+    assert jac.shape == (N_per_dim**dim,)
     assert jac.dtype == dtype_float
     assert anp.max(anp.abs(jac - 4.0)) < 1e-14
 
     # Test vegasmap.accumulate_weight for a fresh VEGAS map
     jf_vec = f_eval * jac
-    jf_vec2 = jf_vec ** 2
+    jf_vec2 = jf_vec**2
     vegasmap.accumulate_weight(y, jf_vec2)
     assert vegasmap.weights.dtype == dtype_float
     assert vegasmap.weights.shape == (dim, N_intervals)

--- a/torchquad/tests/vegas_stratification_test.py
+++ b/torchquad/tests/vegas_stratification_test.py
@@ -49,7 +49,7 @@ def _run_vegas_stratification_checks(backend, precision):
     assert jf.shape == jf2.shape == (strat.N_cubes,)
     assert anp.min(jf2) >= 0.0, "Sums of squared values should be non-negative"
     assert (
-        anp.min(jf ** 2 - jf2) >= 0.0
+        anp.min(jf**2 - jf2) >= 0.0
     ), "Squared sums should be bigger than summed squares"
 
     # Test the dampened sample counts update


### PR DESCRIPTION
With the default code style of the new version the power operator has no spaces if both operands are simple.