### PR TITLE
Change gradient calculation with VEGAS

### DIFF
--- a/torchquad/integration/vegas.py
+++ b/torchquad/integration/vegas.py
@@ -210,6 +210,8 @@ class VEGAS(BaseIntegrator):
             jac = self.map.get_Jac(yrnd)
             jf_vec = f_eval * jac
             jf_vec2 = jf_vec**2
+            if self.backend == "torch":
+                jf_vec2 = jf_vec2.detach()
             self.map.accumulate_weight(yrnd, jf_vec2)  # update map weights
             jf = jf_vec.sum()
             jf2 = jf_vec2.sum()
@@ -250,6 +252,8 @@ class VEGAS(BaseIntegrator):
         jac = self.map.get_Jac(y)  # compute jacobian
         jf_vec = f_eval * jac  # precompute product once
         jf_vec2 = jf_vec**2
+        if self.backend == "torch":
+            jf_vec2 = jf_vec2.detach()
 
         if self.use_grid_improve:  # if adaptive map is used, acc weight
             self.map.accumulate_weight(y, jf_vec2)  # EQ 25

--- a/torchquad/integration/vegas.py
+++ b/torchquad/integration/vegas.py
@@ -226,6 +226,8 @@ class VEGAS(BaseIntegrator):
 
             ih = jf / N_samples  # integral in this step
             sig2 = jf2 / N_samples - pow(jf / N_samples, 2)  # estimated variance
+            if self.backend == "torch":
+                sig2 = sig2.detach()
             # Sometimes rounding errors produce negative values very close to 0
             sig2 = anp.abs(sig2)
             self.results[-1] += ih  # store results
@@ -268,10 +270,12 @@ class VEGAS(BaseIntegrator):
         jf, jf2 = self.strat.accumulate_weight(neval, jf_vec)  # update strat
 
         neval_inverse = 1.0 / astype(neval, y.dtype)
-        ih = jf * neval_inverse * self.strat.V_cubes  # Compute integral per cube
+        ih = jf * (neval_inverse * self.strat.V_cubes)  # Compute integral per cube
 
         # Collect results
         sig2 = jf2 * neval_inverse * (self.strat.V_cubes**2) - pow(ih, 2)
+        if self.backend == "torch":
+            sig2 = sig2.detach()
         # Sometimes rounding errors produce negative values very close to 0
         sig2 = anp.abs(sig2)
         self.results[-1] = ih.sum()  # store results

--- a/torchquad/integration/vegas.py
+++ b/torchquad/integration/vegas.py
@@ -102,10 +102,7 @@ class VEGAS(BaseIntegrator):
         # Note that a larger number of intervals may lead to problems if only few evals are allowed
         # Paper section II B
         N_intervals = max(2, self._N_increment // 10)  # for small N intervals set 2
-        unit_domain = anp.array(
-            [[0.0, 1.0]] * dim, dtype=integration_domain.dtype, like=integration_domain
-        )
-        self.map = VEGASMap(self._dim, unit_domain, N_intervals=N_intervals)
+        self.map = VEGASMap(N_intervals, self._dim, self.backend, self.dtype)
 
         # Initialize VEGAS' stratification
         # Paper section III

--- a/torchquad/integration/vegas_map.py
+++ b/torchquad/integration/vegas_map.py
@@ -129,8 +129,6 @@ class VEGASMap:
         # Get the average values for J^2 f^2 (weights)
         # EQ 17
         z_idx = counts == 0  # zero count indices
-        if infer_backend(weights) == "torch":
-            weights = weights.detach()
         if anp.any(z_idx):
             nnz_idx = anp.logical_not(z_idx)
             weights[nnz_idx] /= counts[nnz_idx]
@@ -257,9 +255,6 @@ class VEGASMap:
             # d_accu_i is used for the interpolation in the new inner edges
             # calculation when adding it to the old inner edges
             d_accu_i = anp.cumsum(delta_d - val_sw_per_dw[:-2], axis=0)
-
-            if self.backend == "torch":
-                d_accu_i = d_accu_i.detach()
 
             # EQ 22
             self.x_edges[i][1:-1] = (


### PR DESCRIPTION
I used torchviz to visualise the autograph graphs generated by torch for the backwards pass: [vegas gradient example graphs.zip](https://github.com/FHof/torchquad/files/8048169/vegas.gradient.example.graphs.zip)
These visualisations reveal that before the changes the variances were used for the gradient and if the gradient was over the integration domain, the gradient flow somehow interacted with the adaptivity.

The variances per iteration are used for the weights calculation in the weighted sum in the final result calculation (the _get_result method), so I think they should be excluded from backpropagation and I added a detach for this.

The integration domain which VEGAS uses internally is now [0,1]^dim and calculating a gradient with respect to the integrand's integration domain almost corresponds to calculating a gradient with a parameter of the integrand which is not part of the integrate method arguments.