### PR TITLE
RNG: Add an option to save and restore the state with PyTorch

### DIFF
--- a/torchquad/integration/utils.py
+++ b/torchquad/integration/utils.py
@@ -204,10 +204,6 @@ class RNG:
             - https://numpy.org/doc/stable/reference/random/generator.html#numpy.random.Generator
             - https://www.tensorflow.org/api_docs/python/tf/random/Generator
               Only the Philox RNG guarantees consistent behaviour in Tensorflow.
-        - For torch, the RNG state is global, so if VEGAS integration uses this and
-          the integrand itself generates random numbers and changes the seed,
-          the calculated grid points may no longer be random.
-          Torch allows to fork the RNG, but this may be slow.
         - Often uniform random numbers are generated in [0, 1) instead of [0, 1].
 
             - numpy: random() is in [0, 1) and uniform() in [0, 1]
@@ -216,12 +212,15 @@ class RNG:
             - tensorflow: uniform() is in [0, 1)
     """
 
-    def __init__(self, backend, seed=None):
-        """Initialize a RNG which can be seeded and is stateful if the backend supports it
+    def __init__(self, backend, seed=None, torch_save_state=False):
+        """Initialize a RNG which can be seeded.
+
+        An initialized RNG maintains a local PRNG state with JAX, Tensorflow and NumPy, and PyTorch if torch_save_state is True.
 
         Args:
             backend (string): Numerical backend, e.g. "torch".
-            seed (int or None): Random number generation seed. If set to None, the RNG is seeded randomly if possible. Defaults to None.
+            seed (int or None, optional): Random number generation seed. If set to None, the RNG is seeded randomly. Defaults to None.
+            torch_save_state (Bool, optional): If True, maintain a separate RNG state for PyTorch. This argument can be helpful to avoid problems with integrand functions which set PyTorch's RNG seed. Unused unless backend is "torch". Defaults to False.
 
         Returns:
             An object whose "uniform" method generates uniform random numbers for the given backend
@@ -234,11 +233,45 @@ class RNG:
         elif backend == "torch":
             import torch
 
-            if seed is None:
-                torch.random.seed()
+            if torch_save_state:
+                # Set and restore the global RNG state before and after
+                # generating random numbers
+
+                if torch.cuda.is_initialized():
+                    # RNG state functions for the current CUDA device
+                    get_state = torch.cuda.get_rng_state
+                    set_state = torch.cuda.set_rng_state
+                else:
+                    # RNG state functions for the Host
+                    get_state = torch.get_rng_state
+                    set_state = torch.set_rng_state
+
+                previous_rng_state = get_state()
+                if seed is None:
+                    torch.random.seed()
+                else:
+                    torch.random.manual_seed(seed)
+                self._rng_state = get_state()
+                set_state(previous_rng_state)
+
+                def uniform_func(size, dtype):
+                    # Swap the state
+                    previous_rng_state = get_state()
+                    set_state(self._rng_state)
+                    # Generate numbers
+                    random_values = torch.rand(size=size, dtype=dtype)
+                    # Swap the state back
+                    self._rng_state = get_state()
+                    set_state(previous_rng_state)
+                    return random_values
+
+                self.uniform = uniform_func
             else:
-                torch.random.manual_seed(seed)
-            self.uniform = lambda size, dtype: torch.rand(size=size, dtype=dtype)
+                if seed is None:
+                    torch.random.seed()
+                else:
+                    torch.random.manual_seed(seed)
+                self.uniform = lambda size, dtype: torch.rand(size=size, dtype=dtype)
         elif backend == "jax":
             from jax.random import PRNGKey, split, uniform
 

--- a/torchquad/integration/vegas.py
+++ b/torchquad/integration/vegas.py
@@ -33,6 +33,7 @@ class VEGAS(BaseIntegrator):
         N=10000,
         integration_domain=None,
         seed=None,
+        rng=None,
         use_grid_improve=True,
         eps_rel=0,
         eps_abs=0,
@@ -50,6 +51,7 @@ class VEGAS(BaseIntegrator):
             N (int, optional): Approximate maximum number of function evaluations to use for the integration. This value can be exceeded if the vegas stratification distributes evaluations per hypercube very unevenly. Defaults to 10000.
             integration_domain (list, optional): Integration domain, e.g. [[-1,1],[0,1]]. Defaults to [-1,1]^dim.
             seed (int, optional): Random number generation seed for the sampling point creation; only set if provided. Defaults to None.
+            rng (RNG, optional): An initialised RNG; this can be used as alternative to the seed argument and to avoid problems with integrand functions which reset PyTorch's RNG seed.
             use_grid_improve (bool, optional): If True, improve the vegas map after each iteration. Defaults to True.
             eps_rel (float, optional): Relative error to abort at. Defaults to 0.
             eps_abs (float, optional): Absolute error to abort at. Defaults to 0.
@@ -91,7 +93,11 @@ class VEGAS(BaseIntegrator):
         if self.backend in ["jax", "tensorflow"]:
             raise ValueError(f"Unsupported numerical backend: {self.backend}")
         self.dtype = integration_domain.dtype
-        self.rng = RNG(backend=self.backend, seed=seed)
+        if rng is None:
+            rng = RNG(backend=self.backend, seed=seed)
+        elif seed is not None:
+            raise ValueError("seed and rng cannot both be passed")
+        self.rng = rng
 
         # Transform the integrand into the [0,1]^dim domain
         domain_starts = integration_domain[:, 0]


### PR DESCRIPTION
With this the user can change the RNG seed in a VEGAS integrand without changing the sample points.
Measurements showed that the uniform function is ca. 4 µs slower with CPU and 30 µs slower with CUDA when the state is saved and restored, so I disabled the option by default.

Alternatively the user can maintain a separate state by modifying the integrand function.